### PR TITLE
Address and additional indexes

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -98,6 +98,7 @@ testScripts = [
     'reindex.py',
     'addressindex.py',
     'timestampindex.py',
+    'spentindex.py',
     'decodescript.py',
     'p2p-fullblocktest.py',
     'blockchain.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -97,6 +97,7 @@ testScripts = [
     'nodehandling.py',
     'reindex.py',
     'addressindex.py',
+    'timestampindex.py',
     'decodescript.py',
     'p2p-fullblocktest.py',
     'blockchain.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -96,6 +96,7 @@ testScripts = [
     'walletbackup.py',
     'nodehandling.py',
     'reindex.py',
+    'addressindex.py',
     'decodescript.py',
     'p2p-fullblocktest.py',
     'blockchain.py',

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -176,6 +176,7 @@ class AddressIndexTest(BitcoinTestFramework):
         for delta in deltas:
             balance3 += delta["satoshis"]
         assert_equal(balance3, change_amount)
+        assert_equal(deltas[0]["address"], address2)
 
         # Check that deltas can be returned from range of block heights
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
@@ -250,6 +251,7 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(len(mempool), 2)
         assert_equal(mempool[0]["txid"], memtxid1)
         assert_equal(mempool[1]["txid"], memtxid2)
+        assert_equal(mempool[0]["address"], address3)
 
         self.nodes[2].generate(1);
         self.sync_all();

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -172,9 +172,8 @@ class AddressIndexTest(BitcoinTestFramework):
         # Check that unspent outputs can be queried
         print "Testing utxos..."
         utxos = self.nodes[1].getaddressutxos({"addresses": [address2]})
-        assert_equal(len(utxos), 2)
-        assert_equal(utxos[0]["satoshis"], 5000000000)
-        assert_equal(utxos[1]["satoshis"], 4899977160)
+        assert_equal(len(utxos), 1)
+        assert_equal(utxos[0]["satoshis"], change_amount)
 
         # Check that indexes will be updated with a reorg
         print "Testing reorg..."
@@ -190,9 +189,8 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(balance4, balance1)
 
         utxos2 = self.nodes[1].getaddressutxos({"addresses": [address2]})
-        assert_equal(len(utxos2), 2)
+        assert_equal(len(utxos2), 1)
         assert_equal(utxos2[0]["satoshis"], 5000000000)
-        assert_equal(utxos2[1]["satoshis"], 5000000000)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -145,7 +145,7 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.vin = [CTxIn(COutPoint(int(spending_txid, 16), 0))]
         send_amount = 1 * 100000000 + 12840
         change_amount = amount - send_amount - 10000
-        tx.vout = [CTxOut(send_amount, scriptPubKey), CTxOut(change_amount, scriptPubKey2)]
+        tx.vout = [CTxOut(change_amount, scriptPubKey2), CTxOut(send_amount, scriptPubKey)]
         tx.rehash()
 
         signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -192,6 +192,21 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(len(utxos2), 1)
         assert_equal(utxos2[0]["satoshis"], 5000000000)
 
+        # Check sorting of utxos
+        self.nodes[2].generate(150)
+
+        txidsort1 = self.nodes[2].sendtoaddress(address2, 50)
+        self.nodes[2].generate(1)
+        txidsort2 = self.nodes[2].sendtoaddress(address2, 50)
+        self.nodes[2].generate(1)
+        self.sync_all()
+
+        utxos3 = self.nodes[1].getaddressutxos({"addresses": [address2]})
+        assert_equal(len(utxos3), 3)
+        assert_equal(utxos3[0]["height"], 114)
+        assert_equal(utxos3[1]["height"], 264)
+        assert_equal(utxos3[2]["height"], 265)
+
         print "Passed\n"
 
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -118,10 +118,12 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsmany[3], sent_txid)
 
         # Check that balances are correct
+        print "Testing balances..."
         balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
         assert_equal(balance0["balance"], 45 * 100000000 + 21)
 
         # Check that balances are correct after spending
+        print "Testing balances after spending..."
         privkey2 = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
         address2 = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
         addressHash2 = "0b2f0a0c31bfe0406b0ccc1381fdbe311946dadc".decode("hex")
@@ -158,14 +160,27 @@ class AddressIndexTest(BitcoinTestFramework):
 
         # Check that deltas are returned correctly
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 0, "end": 200})
-        balance3 = 0;
+        balance3 = 0
         for delta in deltas:
             balance3 += delta["satoshis"]
         assert_equal(balance3, change_amount)
 
         # Check that deltas can be returned from range of block heights
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
-        assert_equal(len(deltas), 1);
+        assert_equal(len(deltas), 1)
+
+        # Check that indexes will be updated with a reorg
+        print "Testing reorg..."
+
+        best_hash = self.nodes[0].getbestblockhash()
+        self.nodes[0].invalidateblock(best_hash)
+        self.nodes[1].invalidateblock(best_hash)
+        self.nodes[2].invalidateblock(best_hash)
+        self.nodes[3].invalidateblock(best_hash)
+        self.sync_all()
+
+        balance4 = self.nodes[1].getaddressbalance(address2)
+        assert_equal(balance4, balance1)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -178,6 +178,10 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(balance3, change_amount)
         assert_equal(deltas[0]["address"], address2)
 
+        # Check that entire range will be queried
+        deltasAll = self.nodes[1].getaddressdeltas({"addresses": [address2]})
+        assert_equal(len(deltasAll), len(deltas))
+
         # Check that deltas can be returned from range of block heights
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
         assert_equal(len(deltas), 1)

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -9,6 +9,9 @@
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+import binascii
 
 class AddressIndexTest(BitcoinTestFramework):
 
@@ -41,6 +44,9 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
+        # Check p2pkh and p2sh address indexes
+        print "Testing p2pkh and p2sh address index..."
+
         txid0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
         txidb0 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 10)
         self.nodes[0].generate(1)
@@ -66,6 +72,28 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsb[0], txidb0);
         assert_equal(txidsb[1], txidb1);
         assert_equal(txidsb[2], txidb2);
+
+        # Check that outputs with the same address will only return one txid
+        print "Testing for txid uniqueness..."
+        addressHash = "6349a418fc4578d10a372b54b45c280cc8c4382f".decode("hex")
+        scriptPubKey = CScript([OP_HASH160, addressHash, OP_EQUAL])
+        unspent = self.nodes[0].listunspent()
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
+        tx.vout = [CTxOut(10, scriptPubKey), CTxOut(11, scriptPubKey)]
+        tx.rehash()
+
+        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode('utf-8'))
+        sent_txid = self.nodes[0].sendrawtransaction(signed_tx['hex'], True)
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        txidsmany = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br");
+        assert_equal(len(txidsmany), 4);
+        assert_equal(txidsmany[3], sent_txid);
+
+        print "Passed\n"
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -46,7 +46,7 @@ class AddressIndexTest(BitcoinTestFramework):
 
         # Check that balances are correct
         balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
-        assert_equal(balance0['balance'], 0);
+        assert_equal(balance0["balance"], 0)
 
         # Check p2pkh and p2sh address indexes
         print "Testing p2pkh and p2sh address index..."
@@ -71,31 +71,31 @@ class AddressIndexTest(BitcoinTestFramework):
 
         self.sync_all()
 
-        txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs");
-        assert_equal(len(txids), 3);
-        assert_equal(txids[0], txid0);
-        assert_equal(txids[1], txid1);
-        assert_equal(txids[2], txid2);
+        txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs")
+        assert_equal(len(txids), 3)
+        assert_equal(txids[0], txid0)
+        assert_equal(txids[1], txid1)
+        assert_equal(txids[2], txid2)
 
-        txidsb = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br");
-        assert_equal(len(txidsb), 3);
-        assert_equal(txidsb[0], txidb0);
-        assert_equal(txidsb[1], txidb1);
-        assert_equal(txidsb[2], txidb2);
+        txidsb = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(len(txidsb), 3)
+        assert_equal(txidsb[0], txidb0)
+        assert_equal(txidsb[1], txidb1)
+        assert_equal(txidsb[2], txidb2)
 
         # Check that multiple addresses works
-        multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]});
-        assert_equal(len(multitxids), 6);
-        assert_equal(multitxids[0], txid0);
-        assert_equal(multitxids[1], txidb0);
-        assert_equal(multitxids[2], txid1);
-        assert_equal(multitxids[3], txidb1);
-        assert_equal(multitxids[4], txid2);
-        assert_equal(multitxids[5], txidb2);
+        multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]})
+        assert_equal(len(multitxids), 6)
+        assert_equal(multitxids[0], txid0)
+        assert_equal(multitxids[1], txidb0)
+        assert_equal(multitxids[2], txid1)
+        assert_equal(multitxids[3], txidb1)
+        assert_equal(multitxids[4], txid2)
+        assert_equal(multitxids[5], txidb2)
 
         # Check that balances are correct
         balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
-        assert_equal(balance0['balance'], 45 * 100000000);
+        assert_equal(balance0["balance"], 45 * 100000000)
 
         # Check that outputs with the same address will only return one txid
         print "Testing for txid uniqueness..."
@@ -107,19 +107,54 @@ class AddressIndexTest(BitcoinTestFramework):
         tx.vout = [CTxOut(10, scriptPubKey), CTxOut(11, scriptPubKey)]
         tx.rehash()
 
-        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode('utf-8'))
-        sent_txid = self.nodes[0].sendrawtransaction(signed_tx['hex'], True)
+        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
+        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
 
         self.nodes[0].generate(1)
         self.sync_all()
 
-        txidsmany = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br");
-        assert_equal(len(txidsmany), 4);
-        assert_equal(txidsmany[3], sent_txid);
+        txidsmany = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(len(txidsmany), 4)
+        assert_equal(txidsmany[3], sent_txid)
 
         # Check that balances are correct
         balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
-        assert_equal(balance0['balance'], 45 * 100000000 + 21);
+        assert_equal(balance0["balance"], 45 * 100000000 + 21)
+
+        # Check that balances are correct after spending
+        privkey2 = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
+        address2 = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
+        addressHash2 = "0b2f0a0c31bfe0406b0ccc1381fdbe311946dadc".decode("hex")
+        scriptPubKey2 = CScript([OP_DUP, OP_HASH160, addressHash2, OP_EQUALVERIFY, OP_CHECKSIG])
+        self.nodes[0].importprivkey(privkey2)
+
+        unspent = self.nodes[0].listunspent()
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
+        amount = unspent[0]["amount"] * 100000000
+        tx.vout = [CTxOut(amount, scriptPubKey2)]
+        tx.rehash()
+        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
+        spending_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        self.nodes[0].generate(1)
+        self.sync_all()
+        balance1 = self.nodes[1].getaddressbalance(address2)
+        assert_equal(balance1["balance"], amount)
+
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(spending_txid, 16), 0))]
+        send_amount = 1 * 100000000 + 12840
+        change_amount = amount - send_amount - 10000
+        tx.vout = [CTxOut(send_amount, scriptPubKey), CTxOut(change_amount, scriptPubKey2)]
+        tx.rehash()
+
+        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
+        sent_txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        balance2 = self.nodes[1].getaddressbalance(address2)
+        assert_equal(balance2["balance"], change_amount)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -174,6 +174,7 @@ class AddressIndexTest(BitcoinTestFramework):
         utxos = self.nodes[1].getaddressutxos({"addresses": [address2]})
         assert_equal(len(utxos), 2)
         assert_equal(utxos[0]["satoshis"], 5000000000)
+        assert_equal(utxos[1]["satoshis"], 4899977160)
 
         # Check that indexes will be updated with a reorg
         print "Testing reorg..."
@@ -187,6 +188,11 @@ class AddressIndexTest(BitcoinTestFramework):
 
         balance4 = self.nodes[1].getaddressbalance(address2)
         assert_equal(balance4, balance1)
+
+        utxos2 = self.nodes[1].getaddressutxos({"addresses": [address2]})
+        assert_equal(len(utxos2), 2)
+        assert_equal(utxos2[0]["satoshis"], 5000000000)
+        assert_equal(utxos2[1]["satoshis"], 5000000000)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -84,6 +84,16 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsb[1], txidb1)
         assert_equal(txidsb[2], txidb2)
 
+        # Check that limiting by height works
+        chain_height = self.nodes[1].getblockcount()
+        height_txids = self.nodes[1].getaddresstxids({
+            "addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br"],
+            "start": 111,
+            "end": 111
+        })
+        assert_equal(len(height_txids), 1)
+        assert_equal(height_txids[0], txidb2)
+
         # Check that multiple addresses works
         multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]})
         assert_equal(len(multitxids), 6)

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -169,6 +169,12 @@ class AddressIndexTest(BitcoinTestFramework):
         deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
         assert_equal(len(deltas), 1)
 
+        # Check that unspent outputs can be queried
+        print "Testing utxos..."
+        utxos = self.nodes[1].getaddressutxos({"addresses": [address2]})
+        assert_equal(len(utxos), 2)
+        assert_equal(utxos[0]["satoshis"], 5000000000)
+
         # Check that indexes will be updated with a reorg
         print "Testing reorg..."
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -156,6 +156,17 @@ class AddressIndexTest(BitcoinTestFramework):
         balance2 = self.nodes[1].getaddressbalance(address2)
         assert_equal(balance2["balance"], change_amount)
 
+        # Check that deltas are returned correctly
+        deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 0, "end": 200})
+        balance3 = 0;
+        for delta in deltas:
+            balance3 += delta["satoshis"]
+        assert_equal(balance3, change_amount)
+
+        # Check that deltas can be returned from range of block heights
+        deltas = self.nodes[1].getaddressdeltas({"addresses": [address2], "start": 113, "end": 113})
+        assert_equal(len(deltas), 1);
+
         print "Passed\n"
 
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -42,11 +42,17 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].getbalance(), 0)
 
         txid0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
+        txidb0 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 10)
         self.nodes[0].generate(1)
+
         txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
+        txidb1 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 15)
         self.nodes[0].generate(1)
+
         txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
+        txidb2 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 20)
         self.nodes[0].generate(1)
+
         self.sync_all()
 
         txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs");
@@ -54,6 +60,13 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txids[0], txid0);
         assert_equal(txids[1], txid1);
         assert_equal(txids[2], txid2);
+
+        txidsb = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br");
+        assert_equal(len(txidsb), 3);
+        assert_equal(txidsb[0], txidb0);
+        assert_equal(txidsb[1], txidb1);
+        assert_equal(txidsb[2], txidb2);
+
 
 if __name__ == '__main__':
     AddressIndexTest().main()

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -41,14 +41,19 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
-        txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
-        txid3 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
+        txid0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
+        self.nodes[0].generate(1)
+        txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
+        self.nodes[0].generate(1)
+        txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
         self.nodes[0].generate(1)
         self.sync_all()
 
         txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs");
         assert_equal(len(txids), 3);
+        assert_equal(txids[0], txid0);
+        assert_equal(txids[1], txid1);
+        assert_equal(txids[2], txid2);
 
 if __name__ == '__main__':
     AddressIndexTest().main()

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test addressindex generation and fetching
+#
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class AddressIndexTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        # Nodes 0/1 are "wallet" nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-addressindex"]))
+        # Nodes 2/3 are used for testing
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-addressindex"]))
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
+
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        print "Mining blocks..."
+        self.nodes[0].generate(105)
+        self.sync_all()
+
+        chain_height = self.nodes[1].getblockcount()
+        assert_equal(chain_height, 105)
+        assert_equal(self.nodes[1].getbalance(), 0)
+        assert_equal(self.nodes[2].getbalance(), 0)
+
+        txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
+        txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
+        txid3 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        txids = self.nodes[1].getaddresstxids("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs");
+        assert_equal(len(txids), 3);
+
+if __name__ == '__main__':
+    AddressIndexTest().main()

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -44,6 +44,10 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
+        # Check that balances are correct
+        balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(balance0['balance'], 0);
+
         # Check p2pkh and p2sh address indexes
         print "Testing p2pkh and p2sh address index..."
 
@@ -89,6 +93,10 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(multitxids[4], txid2);
         assert_equal(multitxids[5], txidb2);
 
+        # Check that balances are correct
+        balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(balance0['balance'], 45 * 100000000);
+
         # Check that outputs with the same address will only return one txid
         print "Testing for txid uniqueness..."
         addressHash = "6349a418fc4578d10a372b54b45c280cc8c4382f".decode("hex")
@@ -108,6 +116,10 @@ class AddressIndexTest(BitcoinTestFramework):
         txidsmany = self.nodes[1].getaddresstxids("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br");
         assert_equal(len(txidsmany), 4);
         assert_equal(txidsmany[3], sent_txid);
+
+        # Check that balances are correct
+        balance0 = self.nodes[1].getaddressbalance("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br")
+        assert_equal(balance0['balance'], 45 * 100000000 + 21);
 
         print "Passed\n"
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -48,14 +48,20 @@ class AddressIndexTest(BitcoinTestFramework):
         print "Testing p2pkh and p2sh address index..."
 
         txid0 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 10)
+        self.nodes[0].generate(1)
+
         txidb0 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 10)
         self.nodes[0].generate(1)
 
         txid1 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 15)
+        self.nodes[0].generate(1)
+
         txidb1 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 15)
         self.nodes[0].generate(1)
 
         txid2 = self.nodes[0].sendtoaddress("mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs", 20)
+        self.nodes[0].generate(1)
+
         txidb2 = self.nodes[0].sendtoaddress("2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", 20)
         self.nodes[0].generate(1)
 
@@ -76,6 +82,12 @@ class AddressIndexTest(BitcoinTestFramework):
         # Check that multiple addresses works
         multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]});
         assert_equal(len(multitxids), 6);
+        assert_equal(multitxids[0], txid0);
+        assert_equal(multitxids[1], txidb0);
+        assert_equal(multitxids[2], txid1);
+        assert_equal(multitxids[3], txidb1);
+        assert_equal(multitxids[4], txid2);
+        assert_equal(multitxids[5], txidb2);
 
         # Check that outputs with the same address will only return one txid
         print "Testing for txid uniqueness..."

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -85,14 +85,15 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsb[2], txidb2)
 
         # Check that limiting by height works
-        chain_height = self.nodes[1].getblockcount()
+        print "Testing querying txids by range of block heights.."
         height_txids = self.nodes[1].getaddresstxids({
             "addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br"],
-            "start": 111,
-            "end": 111
+            "start": 105,
+            "end": 110
         })
-        assert_equal(len(height_txids), 1)
-        assert_equal(height_txids[0], txidb2)
+        assert_equal(len(height_txids), 2)
+        assert_equal(height_txids[0], txidb0)
+        assert_equal(height_txids[1], txidb1)
 
         # Check that multiple addresses works
         multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]})

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -256,6 +256,20 @@ class AddressIndexTest(BitcoinTestFramework):
         mempool2 = self.nodes[2].getaddressmempool({"addresses": [address3]})
         assert_equal(len(mempool2), 0)
 
+        tx = CTransaction()
+        tx.vin = [CTxIn(COutPoint(int(memtxid2, 16), 0))]
+        tx.vout = [CTxOut(amount - 10000, scriptPubKey2)]
+        tx.rehash()
+        self.nodes[2].importprivkey(privKey3)
+        signed_tx3 = self.nodes[2].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
+        memtxid3 = self.nodes[2].sendrawtransaction(signed_tx3["hex"], True)
+        time.sleep(2)
+
+        mempool3 = self.nodes[2].getaddressmempool({"addresses": [address3]})
+        assert_equal(len(mempool3), 1)
+        assert_equal(mempool3[0]["prevtxid"], memtxid2)
+        assert_equal(mempool3[0]["prevout"], 0)
+
         print "Passed\n"
 
 

--- a/qa/rpc-tests/addressindex.py
+++ b/qa/rpc-tests/addressindex.py
@@ -73,6 +73,10 @@ class AddressIndexTest(BitcoinTestFramework):
         assert_equal(txidsb[1], txidb1);
         assert_equal(txidsb[2], txidb2);
 
+        # Check that multiple addresses works
+        multitxids = self.nodes[1].getaddresstxids({"addresses": ["2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br", "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs"]});
+        assert_equal(len(multitxids), 6);
+
         # Check that outputs with the same address will only return one txid
         print "Testing for txid uniqueness..."
         addressHash = "6349a418fc4578d10a372b54b45c280cc8c4382f".decode("hex")

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -66,11 +66,13 @@ class SpentIndexTest(BitcoinTestFramework):
         info = self.nodes[1].getspentinfo({"txid": unspent[0]["txid"], "index": unspent[0]["vout"]})
         assert_equal(info["txid"], txid)
         assert_equal(info["index"], 0)
+        assert_equal(info["height"], 106)
 
         # Check that verbose raw transaction includes spent info
         txVerbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
         assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentTxId"], txid)
         assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentIndex"], 0)
+        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentHeight"], 106)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test addressindex generation and fetching
+#
+
+import time
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.script import *
+from test_framework.mininode import *
+import binascii
+
+class SpentIndexTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        # Nodes 0/1 are "wallet" nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-spentindex"]))
+        # Nodes 2/3 are used for testing
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug", "-spentindex"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-spentindex"]))
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
+
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        print "Mining blocks..."
+        self.nodes[0].generate(105)
+        self.sync_all()
+
+        chain_height = self.nodes[1].getblockcount()
+        assert_equal(chain_height, 105)
+
+        # Check that
+        print "Testing spent index..."
+
+        privkey = "cSdkPxkAjA4HDr5VHgsebAPDEh9Gyub4HK8UJr2DFGGqKKy4K5sG"
+        address = "mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW"
+        addressHash = "0b2f0a0c31bfe0406b0ccc1381fdbe311946dadc".decode("hex")
+        scriptPubKey = CScript([OP_DUP, OP_HASH160, addressHash, OP_EQUALVERIFY, OP_CHECKSIG])
+        unspent = self.nodes[0].listunspent()
+        tx = CTransaction()
+        amount = unspent[0]["amount"] * 100000000
+        tx.vin = [CTxIn(COutPoint(int(unspent[0]["txid"], 16), unspent[0]["vout"]))]
+        tx.vout = [CTxOut(amount, scriptPubKey)]
+        tx.rehash()
+
+        signed_tx = self.nodes[0].signrawtransaction(binascii.hexlify(tx.serialize()).decode("utf-8"))
+        txid = self.nodes[0].sendrawtransaction(signed_tx["hex"], True)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        info = self.nodes[1].getspentinfo({"txid": unspent[0]["txid"], "index": unspent[0]["vout"]})
+        assert_equal(info["txid"], txid)
+        assert_equal(info["index"], 0)
+
+        print "Passed\n"
+
+
+if __name__ == '__main__':
+    SpentIndexTest().main()

--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -27,7 +27,7 @@ class SpentIndexTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-spentindex"]))
         # Nodes 2/3 are used for testing
         self.nodes.append(start_node(2, self.options.tmpdir, ["-debug", "-spentindex"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-spentindex"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-spentindex", "-txindex"]))
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[0], 3)
@@ -62,9 +62,15 @@ class SpentIndexTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
+        # Check that the spentinfo works standalone
         info = self.nodes[1].getspentinfo({"txid": unspent[0]["txid"], "index": unspent[0]["vout"]})
         assert_equal(info["txid"], txid)
         assert_equal(info["index"], 0)
+
+        # Check that verbose raw transaction includes spent info
+        txVerbose = self.nodes[3].getrawtransaction(unspent[0]["txid"], 1)
+        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentTxId"], txid)
+        assert_equal(txVerbose["vout"][unspent[0]["vout"]]["spentIndex"], 0)
 
         print "Passed\n"
 

--- a/qa/rpc-tests/timestampindex.py
+++ b/qa/rpc-tests/timestampindex.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python2
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test timestampindex generation and fetching
+#
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class TimestampIndexTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4)
+
+    def setup_network(self):
+        self.nodes = []
+        # Nodes 0/1 are "wallet" nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-timestampindex"]))
+        # Nodes 2/3 are used for testing
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug", "-timestampindex"]))
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
+
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        print "Mining 5 blocks..."
+        blockhashes = self.nodes[0].generate(5)
+        low = self.nodes[0].getblock(blockhashes[0])["time"]
+        high = self.nodes[0].getblock(blockhashes[4])["time"]
+        self.sync_all()
+        print "Checking timestamp index..."
+        hashes = self.nodes[1].getblockhashes(high, low)
+        assert_equal(len(hashes), 5)
+        assert_equal(sorted(blockhashes), sorted(hashes))
+        print "Passed\n"
+
+
+if __name__ == '__main__':
+    TimestampIndexTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,6 +79,7 @@ endif
 .PHONY: FORCE check-symbols check-security
 # bitcoin core #
 BITCOIN_CORE_H = \
+  addressindex.h \
   addrman.h \
   alert.h \
   amount.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -70,6 +70,7 @@ BITCOIN_TESTS =\
   test/sanity_tests.cpp \
   test/scheduler_tests.cpp \
   test/script_P2SH_tests.cpp \
+  test/script_P2PKH_tests.cpp \
   test/script_tests.cpp \
   test/scriptnum_tests.cpp \
   test/serialize_tests.cpp \

--- a/src/addressindex.h
+++ b/src/addressindex.h
@@ -57,7 +57,7 @@ struct CMempoolAddressDeltaKey
 
 struct CMempoolAddressDeltaKeyCompare
 {
-    bool operator()(const CMempoolAddressDeltaKey& a, const CMempoolAddressDeltaKey& b) {
+    bool operator()(const CMempoolAddressDeltaKey& a, const CMempoolAddressDeltaKey& b) const {
         if (a.type == b.type) {
             if (a.addressBytes == b.addressBytes) {
                 if (a.txhash == b.txhash) {

--- a/src/addressindex.h
+++ b/src/addressindex.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ADDRESSINDEX_H
+#define BITCOIN_ADDRESSINDEX_H
+
+#include "uint256.h"
+#include "amount.h"
+
+struct CMempoolAddressDelta
+{
+    int64_t time;
+    CAmount amount;
+    uint256 prevhash;
+    unsigned int prevout;
+
+    CMempoolAddressDelta(int64_t t, CAmount a, uint256 hash, unsigned int out) {
+        time = t;
+        amount = a;
+        prevhash = hash;
+        prevout = out;
+    }
+
+    CMempoolAddressDelta(int64_t t, CAmount a) {
+        time = t;
+        amount = a;
+        prevhash.SetNull();
+        prevout = 0;
+    }
+};
+
+struct CMempoolAddressDeltaKey
+{
+    int type;
+    uint160 addressBytes;
+    uint256 txhash;
+    unsigned int index;
+    bool spending;
+
+    CMempoolAddressDeltaKey(int addressType, uint160 addressHash, uint256 hash, unsigned int i, bool s) {
+        type = addressType;
+        addressBytes = addressHash;
+        txhash = hash;
+        index = i;
+        spending = s;
+    }
+
+    CMempoolAddressDeltaKey(int addressType, uint160 addressHash) {
+        type = addressType;
+        addressBytes = addressHash;
+        txhash.SetNull();
+        index = 0;
+    }
+};
+
+struct CMempoolAddressDeltaKeyCompare
+{
+    bool operator()(const CMempoolAddressDeltaKey& a, const CMempoolAddressDeltaKey& b) {
+        if (a.type == b.type) {
+            if (a.addressBytes == b.addressBytes) {
+                if (a.txhash == b.txhash) {
+                    return a.index < b.index;
+                } else {
+                    return a.txhash < b.txhash;
+                }
+            } else {
+                return a.addressBytes < b.addressBytes;
+            }
+        } else {
+            return a.type < b.type;
+        }
+    }
+};
+
+#endif // BITCOIN_ADDRESSINDEX_H

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -262,6 +262,23 @@ CTxDestination CBitcoinAddress::Get() const
         return CNoDestination();
 }
 
+bool CBitcoinAddress::GetIndexKey(uint160& hashBytes, int& type) const
+{
+    if (!IsValid()) {
+        return false;
+    } else if (vchVersion == Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS)) {
+        memcpy(&hashBytes, &vchData[0], 20);
+        type = 1;
+        return true;
+    } else if (vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS)) {
+        memcpy(&hashBytes, &vchData[0], 20);
+        type = 2;
+        return true;
+    }
+
+    return false;
+}
+
 bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
 {
     if (!IsValid() || vchVersion != Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS))

--- a/src/base58.h
+++ b/src/base58.h
@@ -116,6 +116,7 @@ public:
 
     CTxDestination Get() const;
     bool GetKeyID(CKeyID &keyID) const;
+    bool GetIndexKey(uint160& hashBytes, int& type) const;
     bool IsScript() const;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -352,6 +352,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageOpt("-addressindex", strprintf(_("Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)"), DEFAULT_ADDRESSINDEX));
     strUsage += HelpMessageOpt("-timestampindex", strprintf(_("Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)"), DEFAULT_TIMESTAMPINDEX));
+    strUsage += HelpMessageOpt("-spentindex", strprintf(_("Maintain a full spent index, used to query the spending txid and input index for an outpoint (default: %u)"), DEFAULT_SPENTINDEX));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -351,6 +351,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
 
     strUsage += HelpMessageOpt("-addressindex", strprintf(_("Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)"), DEFAULT_ADDRESSINDEX));
+    strUsage += HelpMessageOpt("-timestampindex", strprintf(_("Maintain a timestamp index for block hashes, used to query blocks hashes by a range of timestamps (default: %u)"), DEFAULT_TIMESTAMPINDEX));
 
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -350,6 +350,8 @@ std::string HelpMessage(HelpMessageMode mode)
 #endif
     strUsage += HelpMessageOpt("-txindex", strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"), DEFAULT_TXINDEX));
 
+    strUsage += HelpMessageOpt("-addressindex", strprintf(_("Maintain a full address index, used to query for the balance, txids and unspent outputs for addresses (default: %u)"), DEFAULT_ADDRESSINDEX));
+
     strUsage += HelpMessageGroup(_("Connection options:"));
     strUsage += HelpMessageOpt("-addnode=<ip>", _("Add a node to connect to and attempt to keep the connection open"));
     strUsage += HelpMessageOpt("-banscore=<n>", strprintf(_("Threshold for disconnecting misbehaving peers (default: %u)"), DEFAULT_BANSCORE_THRESHOLD));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1208,6 +1208,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
 
         // Store transaction in memory
         pool.addUnchecked(hash, entry, setAncestors, !IsInitialBlockDownload());
+        if (fAddressIndex) {
+            pool.addAddressIndex(entry, view);
+        }
 
         // trim mempool and check if tx was trimmed
         if (!fOverrideMempoolLimit) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1257,6 +1257,18 @@ bool GetAddressIndex(uint160 addressHash, int type,
     return true;
 }
 
+bool GetAddressUnspent(uint160 addressHash, int type,
+                       std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs)
+{
+    if (!fAddressIndex)
+        return error("address index not enabled");
+
+    if (!pblocktree->ReadAddressUnspentIndex(addressHash, type, unspentOutputs))
+        return error("unable to get txids for address");
+
+    return true;
+}
+
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
 {
@@ -2130,6 +2142,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     vPos.reserve(block.vtx.size());
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
 
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
@@ -2154,10 +2167,21 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+
+                        // record spending activity
                         addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+
+                        // remove address from unspent index
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j), CAddressUnspentValue()));
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+
+                        // record spending activity
                         addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+
+                        // remove address from unspent index
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j), CAddressUnspentValue()));
+
                     } else {
                         continue;
                     }
@@ -2191,10 +2215,22 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
                 if (out.scriptPubKey.IsPayToScriptHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+
+                    // record receiving activity
                     addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
+
+                    // record unspent output
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+
+                    // record receiving activity
                     addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
+
+                    // record unspent output
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+
                 } else {
                     continue;
                 }
@@ -2252,9 +2288,15 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         if (!pblocktree->WriteTxIndex(vPos))
             return AbortNode(state, "Failed to write transaction index");
 
-    if (fAddressIndex)
-        if (!pblocktree->WriteAddressIndex(addressIndex))
+    if (fAddressIndex) {
+        if (!pblocktree->WriteAddressIndex(addressIndex)) {
             return AbortNode(state, "Failed to write address index");
+        }
+
+        if (!pblocktree->UpdateAddressUnspentIndex(addressUnspentIndex)) {
+            return AbortNode(state, "Failed to write address unspent index");
+        }
+    }
 
     if (fTimestampIndex)
         if (!pblocktree->WriteTimestampIndex(CTimestampIndexKey(pindex->nTime, pindex->GetBlockHash())))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1926,7 +1926,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
 
                         // restore unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey, undo.nHeight)));
 
 
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
@@ -1936,7 +1936,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
 
                         // restore unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey, undo.nHeight)));
 
                     } else {
                         continue;
@@ -2251,7 +2251,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
 
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
@@ -2260,7 +2260,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey, pindex->nHeight)));
 
                 } else {
                     continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1873,6 +1873,52 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
         }
     }
 
+    // undo address indexes
+    if (fAddressIndex) {
+        std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+
+        for (unsigned int i = 0; i < block.vtx.size(); i++) {
+            const CTransaction &tx = block.vtx[i];
+            const uint256 txhash = tx.GetHash();
+
+            if (!tx.IsCoinBase()) {
+                for (size_t j = 0; j < tx.vin.size(); j++) {
+                    const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
+                    if (prevout.scriptPubKey.IsPayToScriptHash()) {
+                        vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+                    } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
+                        vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+                    } else {
+                        continue;
+                    }
+                }
+            }
+
+            for (unsigned int k = 0; k < tx.vout.size(); k++) {
+                const CTxOut &out = tx.vout[k];
+
+                if (out.scriptPubKey.IsPayToScriptHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
+                } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
+                } else {
+                    continue;
+                }
+
+            }
+
+        }
+
+        if (!pblocktree->EraseAddressIndex(addressIndex)) {
+            return AbortNode(state, "Failed to delete address index");
+        }
+    }
+
+
     // move best block pointer to prevout block
     view.SetBestBlock(pindex->pprev->GetBlockHash());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1848,6 +1848,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
         return error("DisconnectBlock(): block and undo data inconsistent");
 
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+    std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > addressUnspentIndex;
 
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
@@ -1861,10 +1862,22 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
 
                 if (out.scriptPubKey.IsPayToScriptHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+
+                    // undo receiving activity
                     addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
+
+                    // undo unspent index
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, hash, k), CAddressUnspentValue()));
+
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+
+                    // undo receiving activity
                     addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
+
+                    // undo unspent index
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, hash, k), CAddressUnspentValue()));
+
                 } else {
                     continue;
                 }
@@ -1907,10 +1920,23 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+
+                        // undo spending activity
                         addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
+
+                        // restore unspent index
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+
+
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+
+                        // undo spending activity
                         addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
+
+                        // restore unspent index
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+
                     } else {
                         continue;
                     }
@@ -1923,6 +1949,9 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     if (fAddressIndex) {
         if (!pblocktree->EraseAddressIndex(addressIndex)) {
             return AbortNode(state, "Failed to delete address index");
+        }
+        if (!pblocktree->UpdateAddressUnspentIndex(addressUnspentIndex)) {
+            return AbortNode(state, "Failed to write address unspent index");
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1835,10 +1835,31 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     if (blockUndo.vtxundo.size() + 1 != block.vtx.size())
         return error("DisconnectBlock(): block and undo data inconsistent");
 
+    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
         const CTransaction &tx = block.vtx[i];
         uint256 hash = tx.GetHash();
+
+        if (fAddressIndex) {
+
+            for (unsigned int k = tx.vout.size(); k-- > 0;) {
+                const CTxOut &out = tx.vout[k];
+
+                if (out.scriptPubKey.IsPayToScriptHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
+                } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
+                } else {
+                    continue;
+                }
+
+            }
+
+        }
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
@@ -1869,55 +1890,29 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                 const CTxInUndo &undo = txundo.vprevout[j];
                 if (!ApplyTxInUndo(undo, view, out))
                     fClean = false;
-            }
-        }
-    }
 
-    // undo address indexes
-    if (fAddressIndex) {
-        std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
-
-        for (unsigned int i = 0; i < block.vtx.size(); i++) {
-            const CTransaction &tx = block.vtx[i];
-            const uint256 txhash = tx.GetHash();
-
-            if (!tx.IsCoinBase()) {
-                for (size_t j = 0; j < tx.vin.size(); j++) {
+                if (fAddressIndex) {
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
                     } else {
                         continue;
                     }
                 }
             }
-
-            for (unsigned int k = 0; k < tx.vout.size(); k++) {
-                const CTxOut &out = tx.vout[k];
-
-                if (out.scriptPubKey.IsPayToScriptHash()) {
-                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
-                } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
-                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
-                } else {
-                    continue;
-                }
-
-            }
-
         }
+    }
 
+
+    if (fAddressIndex) {
         if (!pblocktree->EraseAddressIndex(addressIndex)) {
             return AbortNode(state, "Failed to delete address index");
         }
     }
-
 
     // move best block pointer to prevout block
     view.SetBestBlock(pindex->pprev->GetBlockHash());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2112,10 +2112,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
                     } else {
                         continue;
                     }
@@ -2149,10 +2149,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
                 if (out.scriptPubKey.IsPayToScriptHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k), out.nValue));
+                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k), out.nValue));
+                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
                 } else {
                     continue;
                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1946,6 +1946,14 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
     }
 
 
+    // move best block pointer to prevout block
+    view.SetBestBlock(pindex->pprev->GetBlockHash());
+
+    if (pfClean) {
+        *pfClean = fClean;
+        return true;
+    }
+
     if (fAddressIndex) {
         if (!pblocktree->EraseAddressIndex(addressIndex)) {
             return AbortNode(state, "Failed to delete address index");
@@ -1953,14 +1961,6 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
         if (!pblocktree->UpdateAddressUnspentIndex(addressUnspentIndex)) {
             return AbortNode(state, "Failed to write address unspent index");
         }
-    }
-
-    // move best block pointer to prevout block
-    view.SetBestBlock(pindex->pprev->GetBlockHash());
-
-    if (pfClean) {
-        *pfClean = fClean;
-        return true;
     }
 
     return fClean;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,7 @@ bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
 bool fAddressIndex = false;
+bool fTimestampIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
@@ -1233,6 +1234,17 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     return res;
 }
 
+bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes)
+{
+    if (!fTimestampIndex)
+        return error("Timestamp index not enabled");
+
+    if (!pblocktree->ReadTimestampIndex(high, low, hashes))
+        return error("Unable to get hashes for timestamps");
+
+    return true;
+}
+
 bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex)
 {
     if (!fAddressIndex)
@@ -2199,8 +2211,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             return AbortNode(state, "Failed to write transaction index");
 
     if (fAddressIndex)
-	if (!pblocktree->WriteAddressIndex(addressIndex))
-	    return AbortNode(state, "Failed to write address index");
+        if (!pblocktree->WriteAddressIndex(addressIndex))
+            return AbortNode(state, "Failed to write address index");
+
+    if (fTimestampIndex)
+        if (!pblocktree->WriteTimestampIndex(CTimestampIndexKey(pindex->nTime, pindex->GetBlockHash())))
+            return AbortNode(state, "Failed to write timestamp index");
 
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
@@ -3571,6 +3587,10 @@ bool static LoadBlockIndexDB()
     pblocktree->ReadFlag("addressindex", fAddressIndex);
     LogPrintf("%s: address index %s\n", __func__, fAddressIndex ? "enabled" : "disabled");
 
+    // Check whether we have a timestamp index
+    pblocktree->ReadFlag("timestampindex", fTimestampIndex);
+    LogPrintf("%s: timestamp index %s\n", __func__, fTimestampIndex ? "enabled" : "disabled");
+
     // Load pointer to end of best chain
     BlockMap::iterator it = mapBlockIndex.find(pcoinsTip->GetBestBlock());
     if (it == mapBlockIndex.end())
@@ -3732,6 +3752,10 @@ bool InitBlockIndex(const CChainParams& chainparams)
     // Use the provided setting for -addressindex in the new database
     fAddressIndex = GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX);
     pblocktree->WriteFlag("addressindex", fAddressIndex);
+
+    // Use the provided setting for -timestampindex in the new database
+    fTimestampIndex = GetBoolArg("-timestampindex", DEFAULT_TIMESTAMPINDEX);
+    pblocktree->WriteFlag("timestampindex", fTimestampIndex);
 
     LogPrintf("Initializing databases...\n");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2100,10 +2100,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 2, txhash, j), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j), prevout.nValue * -1));
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
-                        addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 1, txhash, j), prevout.nValue * -1));
+                        addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j), prevout.nValue * -1));
                     } else {
                         continue;
                     }
@@ -2137,17 +2137,16 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
                 if (out.scriptPubKey.IsPayToScriptHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 2, txhash, k), out.nValue));
+                    addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k), out.nValue));
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
-                    addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 1, txhash, k), out.nValue));
+                    addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k), out.nValue));
                 } else {
                     continue;
                 }
 
             }
         }
-
 
         CTxUndo undoDummy;
         if (i > 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1252,7 +1252,7 @@ bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::v
 bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value)
 {
     if (!fSpentIndex)
-        return error("spent index not enabled");
+        return false;
 
     if (!pblocktree->ReadSpentIndex(key, value))
         return error("unable to get spent info");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,6 +65,7 @@ int nScriptCheckThreads = 0;
 bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
+bool fAddressIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
@@ -1232,6 +1233,17 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     return res;
 }
 
+bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex)
+{
+    if (!fAddressIndex)
+        return error("%s: address index not enabled");
+
+    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex))
+        return error("%s: unable to get txids for address");
+
+    return true;
+}
+
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256 &hash, CTransaction &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
 {
@@ -2063,9 +2075,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     std::vector<std::pair<uint256, CDiskTxPos> > vPos;
     vPos.reserve(block.vtx.size());
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
+    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+
     for (unsigned int i = 0; i < block.vtx.size(); i++)
     {
         const CTransaction &tx = block.vtx[i];
+        const uint256 txhash = tx.GetHash();
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
@@ -2078,6 +2093,22 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             if (!view.HaveInputs(tx))
                 return state.DoS(100, error("ConnectBlock(): inputs missing/spent"),
                                  REJECT_INVALID, "bad-txns-inputs-missingorspent");
+
+            if (fAddressIndex)
+            {
+                for (size_t j = 0; j < tx.vin.size(); j++) {
+                    const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
+                    if (prevout.scriptPubKey.IsPayToScriptHash()) {
+                        vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+                        addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 2, txhash, j), prevout.nValue * -1));
+                    } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
+                        vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+                        addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 1, txhash, j), prevout.nValue * -1));
+                    } else {
+                        continue;
+                    }
+                }
+            }
 
             if (fStrictPayToScriptHash)
             {
@@ -2099,6 +2130,24 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     tx.GetHash().ToString(), FormatStateMessage(state));
             control.Add(vChecks);
         }
+
+        if (fAddressIndex) {
+            for (unsigned int k = 0; k < tx.vout.size(); k++) {
+                const CTxOut &out = tx.vout[k];
+
+                if (out.scriptPubKey.IsPayToScriptHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 2, txhash, k), out.nValue));
+                } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
+                    vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+                    addressIndex.push_back(make_pair(CAddressIndexKey(uint160(hashBytes), 1, txhash, k), out.nValue));
+                } else {
+                    continue;
+                }
+
+            }
+        }
+
 
         CTxUndo undoDummy;
         if (i > 0) {
@@ -2149,6 +2198,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (fTxIndex)
         if (!pblocktree->WriteTxIndex(vPos))
             return AbortNode(state, "Failed to write transaction index");
+
+    if (fAddressIndex)
+	if (!pblocktree->WriteAddressIndex(addressIndex))
+	    return AbortNode(state, "Failed to write address index");
 
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
@@ -3515,6 +3568,10 @@ bool static LoadBlockIndexDB()
     pblocktree->ReadFlag("txindex", fTxIndex);
     LogPrintf("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
 
+    // Check whether we have an address index
+    pblocktree->ReadFlag("addressindex", fAddressIndex);
+    LogPrintf("%s: address index %s\n", __func__, fAddressIndex ? "enabled" : "disabled");
+
     // Load pointer to end of best chain
     BlockMap::iterator it = mapBlockIndex.find(pcoinsTip->GetBestBlock());
     if (it == mapBlockIndex.end())
@@ -3672,6 +3729,11 @@ bool InitBlockIndex(const CChainParams& chainparams)
     // Use the provided setting for -txindex in the new database
     fTxIndex = GetBoolArg("-txindex", DEFAULT_TXINDEX);
     pblocktree->WriteFlag("txindex", fTxIndex);
+
+    // Use the provided setting for -addressindex in the new database
+    fAddressIndex = GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX);
+    pblocktree->WriteFlag("addressindex", fAddressIndex);
+
     LogPrintf("Initializing databases...\n");
 
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1867,7 +1867,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
 
                     // undo unspent index
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, hash, k), CAddressUnspentValue()));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), hash, k), CAddressUnspentValue()));
 
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
@@ -1876,7 +1876,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, k, false), out.nValue));
 
                     // undo unspent index
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, hash, k), CAddressUnspentValue()));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), hash, k), CAddressUnspentValue()));
 
                 } else {
                     continue;
@@ -1917,6 +1917,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                     fClean = false;
 
                 if (fAddressIndex) {
+                    const CTxIn input = tx.vin[j];
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
@@ -1925,7 +1926,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
 
                         // restore unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, hash, j), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
 
 
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
@@ -1935,7 +1936,7 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
                         addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j, true), prevout.nValue * -1));
 
                         // restore unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, hash, j), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue(prevout.nValue, prevout.scriptPubKey)));
 
                     } else {
                         continue;
@@ -2193,6 +2194,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             if (fAddressIndex)
             {
                 for (size_t j = 0; j < tx.vin.size(); j++) {
+                    const CTxIn input = tx.vin[j];
                     const CTxOut &prevout = view.GetOutputFor(tx.vin[j]);
                     if (prevout.scriptPubKey.IsPayToScriptHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
@@ -2201,7 +2203,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
 
                         // remove address from unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, j), CAddressUnspentValue()));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
                     } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
                         vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
 
@@ -2209,7 +2211,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                         addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j, true), prevout.nValue * -1));
 
                         // remove address from unspent index
-                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, j), CAddressUnspentValue()));
+                        addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), input.prevout.hash, input.prevout.n), CAddressUnspentValue()));
 
                     } else {
                         continue;
@@ -2249,7 +2251,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), pindex->nHeight, i, txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(2, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
 
                 } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
                     vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
@@ -2258,7 +2260,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     addressIndex.push_back(make_pair(CAddressIndexKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k, false), out.nValue));
 
                     // record unspent output
-                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), pindex->nHeight, i, txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
+                    addressUnspentIndex.push_back(make_pair(CAddressUnspentKey(1, uint160(hashBytes), txhash, k), CAddressUnspentValue(out.nValue, out.scriptPubKey)));
 
                 } else {
                     continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1245,13 +1245,14 @@ bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::v
     return true;
 }
 
-bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex)
+bool GetAddressIndex(uint160 addressHash, int type,
+                     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex, int start, int end)
 {
     if (!fAddressIndex)
-        return error("%s: address index not enabled");
+        return error("address index not enabled");
 
-    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex))
-        return error("%s: unable to get txids for address");
+    if (!pblocktree->ReadAddressIndex(addressHash, type, addressIndex, start, end))
+        return error("unable to get txids for address");
 
     return true;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -344,6 +344,93 @@ struct CTimestampIndexKey {
     }
 };
 
+struct CAddressUnspentKey {
+    unsigned int type;
+    uint160 hashBytes;
+    int blockHeight;
+    unsigned int txindex;
+    uint256 txhash;
+    size_t index;
+
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 65;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata8(s, type);
+        hashBytes.Serialize(s, nType, nVersion);
+        // Heights are stored big-endian for key sorting in LevelDB
+        ser_writedata32be(s, blockHeight);
+        ser_writedata32be(s, txindex);
+        txhash.Serialize(s, nType, nVersion);
+        ser_writedata32(s, index);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        type = ser_readdata8(s);
+        hashBytes.Unserialize(s, nType, nVersion);
+        blockHeight = ser_readdata32be(s);
+        txindex = ser_readdata32be(s);
+        txhash.Unserialize(s, nType, nVersion);
+        index = ser_readdata32(s);
+    }
+
+    CAddressUnspentKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
+                     uint256 txid, size_t indexValue) {
+        type = addressType;
+        hashBytes = addressHash;
+        blockHeight = height;
+        txindex = blockindex;
+        txhash = txid;
+        index = indexValue;
+    }
+
+    CAddressUnspentKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        type = 0;
+        hashBytes.SetNull();
+        blockHeight = 0;
+        txindex = 0;
+        txhash.SetNull();
+        index = 0;
+    }
+};
+
+struct CAddressUnspentValue {
+    CAmount satoshis;
+    CScript script;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(satoshis);
+        READWRITE(*(CScriptBase*)(&script));
+    }
+
+    CAddressUnspentValue(CAmount sats, CScript scriptPubKey) {
+        satoshis = sats;
+        script = scriptPubKey;
+    }
+
+    CAddressUnspentValue() {
+        SetNull();
+    }
+
+    void SetNull() {
+        satoshis = 0;
+        script = CScript();
+    }
+
+    bool IsNull() const {
+        return (satoshis == 0);
+    }
+
+};
+
 struct CAddressIndexKey {
     unsigned int type;
     uint160 hashBytes;
@@ -354,7 +441,7 @@ struct CAddressIndexKey {
     bool spending;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
-        return 65;
+        return 66;
     }
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
@@ -568,6 +655,8 @@ bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::v
 bool GetAddressIndex(uint160 addressHash, int type,
                      std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
                      int start = 0, int end = 0);
+bool GetAddressUnspent(uint160 addressHash, int type,
+                       std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &unspentOutputs);
 
 /** Functions for disk access for blocks */
 bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart);

--- a/src/main.h
+++ b/src/main.h
@@ -105,6 +105,7 @@ static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
+static const bool DEFAULT_ADDRESSINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
@@ -281,6 +282,42 @@ struct CNodeStateStats {
     std::vector<int> vHeightInFlight;
 };
 
+struct CAddressIndexKey {
+    uint160 hashBytes;
+    unsigned int type;
+    uint256 txhash;
+    size_t index;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(hashBytes);
+        READWRITE(type);
+        READWRITE(txhash);
+        READWRITE(index);
+    }
+
+    CAddressIndexKey(uint160 addressHash, unsigned int addressType, uint256 txid, size_t txindex) {
+        hashBytes = addressHash;
+        type = addressType;
+        txhash = txid;
+        index = txindex;
+    }
+
+    CAddressIndexKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        hashBytes.SetNull();
+        type = 0;
+        txhash.SetNull();
+        index = 0;
+    }
+
+};
+
 struct CDiskTxPos : public CDiskBlockPos
 {
     unsigned int nTxOffset; // after header
@@ -387,6 +424,7 @@ public:
     ScriptError GetScriptError() const { return error; }
 };
 
+bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
 
 /** Functions for disk access for blocks */
 bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart);

--- a/src/main.h
+++ b/src/main.h
@@ -552,23 +552,14 @@ struct CAddressIndexKey {
 struct CAddressIndexIteratorKey {
     unsigned int type;
     uint160 hashBytes;
-    bool includeHeight;
-    int blockHeight;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
-        if (includeHeight) {
-            return 25;
-        } else {
-            return 21;
-        }
+        return 21;
     }
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
         ser_writedata8(s, type);
         hashBytes.Serialize(s, nType, nVersion);
-        if (includeHeight) {
-            ser_writedata32be(s, blockHeight);
-        }
     }
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
@@ -579,14 +570,6 @@ struct CAddressIndexIteratorKey {
     CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash) {
         type = addressType;
         hashBytes = addressHash;
-        includeHeight = false;
-    }
-
-    CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash, int height) {
-        type = addressType;
-        hashBytes = addressHash;
-        blockHeight = height;
-        includeHeight = true;
     }
 
     CAddressIndexIteratorKey() {
@@ -596,7 +579,44 @@ struct CAddressIndexIteratorKey {
     void SetNull() {
         type = 0;
         hashBytes.SetNull();
-        includeHeight = false;
+    }
+};
+
+struct CAddressIndexIteratorHeightKey {
+    unsigned int type;
+    uint160 hashBytes;
+    int blockHeight;
+
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 25;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata8(s, type);
+        hashBytes.Serialize(s, nType, nVersion);
+        ser_writedata32be(s, blockHeight);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        type = ser_readdata8(s);
+        hashBytes.Unserialize(s, nType, nVersion);
+        blockHeight = ser_readdata32be(s);
+    }
+
+    CAddressIndexIteratorHeightKey(unsigned int addressType, uint160 addressHash, int height) {
+        type = addressType;
+        hashBytes = addressHash;
+        blockHeight = height;
+    }
+
+    CAddressIndexIteratorHeightKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        type = 0;
+        hashBytes.SetNull();
+        blockHeight = 0;
     }
 };
 

--- a/src/main.h
+++ b/src/main.h
@@ -107,6 +107,7 @@ static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
 static const bool DEFAULT_ADDRESSINDEX = false;
 static const bool DEFAULT_TIMESTAMPINDEX = false;
+static const bool DEFAULT_SPENTINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
@@ -281,6 +282,69 @@ struct CNodeStateStats {
     int nSyncHeight;
     int nCommonHeight;
     std::vector<int> vHeightInFlight;
+};
+
+struct CSpentIndexKey {
+    uint256 txid;
+    unsigned int outputIndex;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(txid);
+        READWRITE(outputIndex);
+    }
+
+    CSpentIndexKey(uint256 t, unsigned int i) {
+        txid = t;
+        outputIndex = i;
+    }
+
+    CSpentIndexKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        txid.SetNull();
+        outputIndex = 0;
+    }
+
+};
+
+struct CSpentIndexValue {
+    uint256 txid;
+    unsigned int inputIndex;
+    int blockHeight;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(txid);
+        READWRITE(inputIndex);
+        READWRITE(blockHeight);
+    }
+
+    CSpentIndexValue(uint256 t, unsigned int i, int h) {
+        txid = t;
+        inputIndex = i;
+        blockHeight = h;
+    }
+
+    CSpentIndexValue() {
+        SetNull();
+    }
+
+    void SetNull() {
+        txid.SetNull();
+        inputIndex = 0;
+        blockHeight = 0;
+    }
+
+    bool IsNull() const {
+        return txid.IsNull();
+    }
 };
 
 struct CTimestampIndexIteratorKey {
@@ -643,6 +707,7 @@ public:
 };
 
 bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes);
+bool GetSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
 bool GetAddressIndex(uint160 addressHash, int type,
                      std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
                      int start = 0, int end = 0);

--- a/src/main.h
+++ b/src/main.h
@@ -347,21 +347,16 @@ struct CTimestampIndexKey {
 struct CAddressUnspentKey {
     unsigned int type;
     uint160 hashBytes;
-    int blockHeight;
-    unsigned int txindex;
     uint256 txhash;
     size_t index;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
-        return 65;
+        return 57;
     }
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
         ser_writedata8(s, type);
         hashBytes.Serialize(s, nType, nVersion);
-        // Heights are stored big-endian for key sorting in LevelDB
-        ser_writedata32be(s, blockHeight);
-        ser_writedata32be(s, txindex);
         txhash.Serialize(s, nType, nVersion);
         ser_writedata32(s, index);
     }
@@ -369,18 +364,13 @@ struct CAddressUnspentKey {
     void Unserialize(Stream& s, int nType, int nVersion) {
         type = ser_readdata8(s);
         hashBytes.Unserialize(s, nType, nVersion);
-        blockHeight = ser_readdata32be(s);
-        txindex = ser_readdata32be(s);
         txhash.Unserialize(s, nType, nVersion);
         index = ser_readdata32(s);
     }
 
-    CAddressUnspentKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
-                     uint256 txid, size_t indexValue) {
+    CAddressUnspentKey(unsigned int addressType, uint160 addressHash, uint256 txid, size_t indexValue) {
         type = addressType;
         hashBytes = addressHash;
-        blockHeight = height;
-        txindex = blockindex;
         txhash = txid;
         index = indexValue;
     }
@@ -392,8 +382,6 @@ struct CAddressUnspentKey {
     void SetNull() {
         type = 0;
         hashBytes.SetNull();
-        blockHeight = 0;
-        txindex = 0;
         txhash.SetNull();
         index = 0;
     }
@@ -421,14 +409,13 @@ struct CAddressUnspentValue {
     }
 
     void SetNull() {
-        satoshis = 0;
-        script = CScript();
+        satoshis = -1;
+        script.clear();
     }
 
     bool IsNull() const {
-        return (satoshis == 0);
+        return (satoshis == -1);
     }
-
 };
 
 struct CAddressIndexKey {

--- a/src/main.h
+++ b/src/main.h
@@ -351,6 +351,7 @@ struct CAddressIndexKey {
     unsigned int txindex;
     uint256 txhash;
     size_t outindex;
+    bool spending;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
         return 65;
@@ -364,6 +365,8 @@ struct CAddressIndexKey {
         ser_writedata32be(s, txindex);
         txhash.Serialize(s, nType, nVersion);
         ser_writedata32(s, outindex);
+        char f = spending;
+        ser_writedata8(s, f);
     }
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
@@ -373,16 +376,19 @@ struct CAddressIndexKey {
         txindex = ser_readdata32be(s);
         txhash.Unserialize(s, nType, nVersion);
         outindex = ser_readdata32(s);
+        char f = ser_readdata8(s);
+        spending = f;
     }
 
     CAddressIndexKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
-                     uint256 txid, size_t outputIndex) {
+                     uint256 txid, size_t outputIndex, bool isSpending) {
         type = addressType;
         hashBytes = addressHash;
         blockHeight = height;
         txindex = blockindex;
         txhash = txid;
         outindex = outputIndex;
+        spending = isSpending;
     }
 
     CAddressIndexKey() {
@@ -396,6 +402,7 @@ struct CAddressIndexKey {
         txindex = 0;
         txhash.SetNull();
         outindex = 0;
+        spending = false;
     }
 
 };

--- a/src/main.h
+++ b/src/main.h
@@ -283,26 +283,33 @@ struct CNodeStateStats {
 };
 
 struct CAddressIndexKey {
-    uint160 hashBytes;
     unsigned int type;
+    uint160 hashBytes;
+    int blockHeight;
+    unsigned int txindex;
     uint256 txhash;
-    size_t index;
+    size_t outindex;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(hashBytes);
         READWRITE(type);
+        READWRITE(hashBytes);
+        READWRITE(blockHeight);
+        READWRITE(txindex);
         READWRITE(txhash);
-        READWRITE(index);
+        READWRITE(outindex);
     }
 
-    CAddressIndexKey(uint160 addressHash, unsigned int addressType, uint256 txid, size_t txindex) {
-        hashBytes = addressHash;
+    CAddressIndexKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
+                     uint256 txid, size_t outputIndex) {
         type = addressType;
+        hashBytes = addressHash;
+        blockHeight = height;
+        txindex = blockindex;
         txhash = txid;
-        index = txindex;
+        outindex = outputIndex;
     }
 
     CAddressIndexKey() {
@@ -310,12 +317,41 @@ struct CAddressIndexKey {
     }
 
     void SetNull() {
-        hashBytes.SetNull();
         type = 0;
+        hashBytes.SetNull();
+        blockHeight = 0;
+        txindex = 0;
         txhash.SetNull();
-        index = 0;
+        outindex = 0;
     }
 
+};
+
+struct CAddressIndexIteratorKey {
+    unsigned int type;
+    uint160 hashBytes;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(type);
+        READWRITE(hashBytes);
+    }
+
+    CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash) {
+        type = addressType;
+        hashBytes = addressHash;
+    }
+
+    CAddressIndexIteratorKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        type = 0;
+        hashBytes.SetNull();
+    }
 };
 
 struct CDiskTxPos : public CDiskBlockPos

--- a/src/main.h
+++ b/src/main.h
@@ -350,7 +350,7 @@ struct CAddressIndexKey {
     int blockHeight;
     unsigned int txindex;
     uint256 txhash;
-    size_t outindex;
+    size_t index;
     bool spending;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
@@ -364,7 +364,7 @@ struct CAddressIndexKey {
         ser_writedata32be(s, blockHeight);
         ser_writedata32be(s, txindex);
         txhash.Serialize(s, nType, nVersion);
-        ser_writedata32(s, outindex);
+        ser_writedata32(s, index);
         char f = spending;
         ser_writedata8(s, f);
     }
@@ -375,19 +375,19 @@ struct CAddressIndexKey {
         blockHeight = ser_readdata32be(s);
         txindex = ser_readdata32be(s);
         txhash.Unserialize(s, nType, nVersion);
-        outindex = ser_readdata32(s);
+        index = ser_readdata32(s);
         char f = ser_readdata8(s);
         spending = f;
     }
 
     CAddressIndexKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
-                     uint256 txid, size_t outputIndex, bool isSpending) {
+                     uint256 txid, size_t indexValue, bool isSpending) {
         type = addressType;
         hashBytes = addressHash;
         blockHeight = height;
         txindex = blockindex;
         txhash = txid;
-        outindex = outputIndex;
+        index = indexValue;
         spending = isSpending;
     }
 
@@ -401,7 +401,7 @@ struct CAddressIndexKey {
         blockHeight = 0;
         txindex = 0;
         txhash.SetNull();
-        outindex = 0;
+        index = 0;
         spending = false;
     }
 
@@ -410,14 +410,23 @@ struct CAddressIndexKey {
 struct CAddressIndexIteratorKey {
     unsigned int type;
     uint160 hashBytes;
+    bool includeHeight;
+    int blockHeight;
 
     size_t GetSerializeSize(int nType, int nVersion) const {
-        return 21;
+        if (includeHeight) {
+            return 25;
+        } else {
+            return 21;
+        }
     }
     template<typename Stream>
     void Serialize(Stream& s, int nType, int nVersion) const {
         ser_writedata8(s, type);
         hashBytes.Serialize(s, nType, nVersion);
+        if (includeHeight) {
+            ser_writedata32be(s, blockHeight);
+        }
     }
     template<typename Stream>
     void Unserialize(Stream& s, int nType, int nVersion) {
@@ -428,6 +437,14 @@ struct CAddressIndexIteratorKey {
     CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash) {
         type = addressType;
         hashBytes = addressHash;
+        includeHeight = false;
+    }
+
+    CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash, int height) {
+        type = addressType;
+        hashBytes = addressHash;
+        blockHeight = height;
+        includeHeight = true;
     }
 
     CAddressIndexIteratorKey() {
@@ -437,6 +454,7 @@ struct CAddressIndexIteratorKey {
     void SetNull() {
         type = 0;
         hashBytes.SetNull();
+        includeHeight = false;
     }
 };
 
@@ -547,7 +565,9 @@ public:
 };
 
 bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes);
-bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
+bool GetAddressIndex(uint160 addressHash, int type,
+                     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
+                     int start = 0, int end = 0);
 
 /** Functions for disk access for blocks */
 bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& messageStart);

--- a/src/main.h
+++ b/src/main.h
@@ -390,6 +390,7 @@ struct CAddressUnspentKey {
 struct CAddressUnspentValue {
     CAmount satoshis;
     CScript script;
+    int blockHeight;
 
     ADD_SERIALIZE_METHODS;
 
@@ -397,11 +398,13 @@ struct CAddressUnspentValue {
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         READWRITE(satoshis);
         READWRITE(*(CScriptBase*)(&script));
+        READWRITE(blockHeight);
     }
 
-    CAddressUnspentValue(CAmount sats, CScript scriptPubKey) {
+    CAddressUnspentValue(CAmount sats, CScript scriptPubKey, int height) {
         satoshis = sats;
         script = scriptPubKey;
+        blockHeight = height;
     }
 
     CAddressUnspentValue() {
@@ -411,6 +414,7 @@ struct CAddressUnspentValue {
     void SetNull() {
         satoshis = -1;
         script.clear();
+        blockHeight = 0;
     }
 
     bool IsNull() const {

--- a/src/main.h
+++ b/src/main.h
@@ -290,16 +290,27 @@ struct CAddressIndexKey {
     uint256 txhash;
     size_t outindex;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(type);
-        READWRITE(hashBytes);
-        READWRITE(blockHeight);
-        READWRITE(txindex);
-        READWRITE(txhash);
-        READWRITE(outindex);
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 65;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata8(s, type);
+        hashBytes.Serialize(s, nType, nVersion);
+        // Heights are stored big-endian for key sorting in LevelDB
+        ser_writedata32be(s, blockHeight);
+        ser_writedata32be(s, txindex);
+        txhash.Serialize(s, nType, nVersion);
+        ser_writedata32(s, outindex);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        type = ser_readdata8(s);
+        hashBytes.Unserialize(s, nType, nVersion);
+        blockHeight = ser_readdata32be(s);
+        txindex = ser_readdata32be(s);
+        txhash.Unserialize(s, nType, nVersion);
+        outindex = ser_readdata32(s);
     }
 
     CAddressIndexKey(unsigned int addressType, uint160 addressHash, int height, int blockindex,
@@ -331,12 +342,18 @@ struct CAddressIndexIteratorKey {
     unsigned int type;
     uint160 hashBytes;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
-        READWRITE(type);
-        READWRITE(hashBytes);
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 21;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata8(s, type);
+        hashBytes.Serialize(s, nType, nVersion);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        type = ser_readdata8(s);
+        hashBytes.Unserialize(s, nType, nVersion);
     }
 
     CAddressIndexIteratorKey(unsigned int addressType, uint160 addressHash) {

--- a/src/main.h
+++ b/src/main.h
@@ -106,6 +106,7 @@ static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
 static const bool DEFAULT_ADDRESSINDEX = false;
+static const bool DEFAULT_TIMESTAMPINDEX = false;
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
@@ -280,6 +281,67 @@ struct CNodeStateStats {
     int nSyncHeight;
     int nCommonHeight;
     std::vector<int> vHeightInFlight;
+};
+
+struct CTimestampIndexIteratorKey {
+    unsigned int timestamp;
+
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 4;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata32be(s, timestamp);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        timestamp = ser_readdata32be(s);
+    }
+
+    CTimestampIndexIteratorKey(unsigned int time) {
+        timestamp = time;
+    }
+
+    CTimestampIndexIteratorKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        timestamp = 0;
+    }
+};
+
+struct CTimestampIndexKey {
+    unsigned int timestamp;
+    uint256 blockHash;
+
+    size_t GetSerializeSize(int nType, int nVersion) const {
+        return 36;
+    }
+    template<typename Stream>
+    void Serialize(Stream& s, int nType, int nVersion) const {
+        ser_writedata32be(s, timestamp);
+        blockHash.Serialize(s, nType, nVersion);
+    }
+    template<typename Stream>
+    void Unserialize(Stream& s, int nType, int nVersion) {
+        timestamp = ser_readdata32be(s);
+        blockHash.Unserialize(s, nType, nVersion);
+    }
+
+    CTimestampIndexKey(unsigned int time, uint256 hash) {
+        timestamp = time;
+        blockHash = hash;
+    }
+
+    CTimestampIndexKey() {
+        SetNull();
+    }
+
+    void SetNull() {
+        timestamp = 0;
+        blockHash.SetNull();
+    }
 };
 
 struct CAddressIndexKey {
@@ -477,6 +539,7 @@ public:
     ScriptError GetScriptError() const { return error; }
 };
 
+bool GetTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &hashes);
 bool GetAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
 
 /** Functions for disk access for blocks */

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -275,6 +275,38 @@ UniValue getrawmempool(const UniValue& params, bool fHelp)
     return mempoolToJSON(fVerbose);
 }
 
+UniValue getblockhashes(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 2)
+        throw runtime_error(
+            "getblockhashes timestamp\n"
+            "\nReturns array of hashes of blocks within the timestamp range provided.\n"
+            "\nArguments:\n"
+            "1. high         (numeric, required) The newer block timestamp\n"
+            "2. low          (numeric, required) The older block timestamp\n"
+            "\nResult:\n"
+            "["
+            "  \"hash\"         (string) The block hash\n"
+            "]"
+            "\nExamples:\n"
+        );
+
+    unsigned int high = params[0].get_int();
+    unsigned int low = params[1].get_int();
+    std::vector<uint256> blockHashes;
+
+    if (!GetTimestampIndex(high, low, blockHashes)) {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for block hashes");
+    }
+
+    UniValue result(UniValue::VARR);
+    for (std::vector<uint256>::const_iterator it=blockHashes.begin(); it!=blockHashes.end(); it++) {
+        result.push_back(it->GetHex());
+    }
+
+    return result;
+}
+
 UniValue getblockhash(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 1)

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -534,7 +534,7 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
 
         output.push_back(Pair("address", address));
         output.push_back(Pair("txid", it->first.txhash.GetHex()));
-        output.push_back(Pair("outputIndex", it->first.index));
+        output.push_back(Pair("outputIndex", (int)it->first.index));
         output.push_back(Pair("script", HexStr(it->second.script.begin(), it->second.script.end())));
         output.push_back(Pair("satoshis", it->second.satoshis));
         output.push_back(Pair("height", it->second.blockHeight));
@@ -594,7 +594,7 @@ UniValue getaddressdeltas(const UniValue& params, bool fHelp)
         UniValue delta(UniValue::VOBJ);
         delta.push_back(Pair("satoshis", it->second));
         delta.push_back(Pair("txid", it->first.txhash.GetHex()));
-        delta.push_back(Pair("index", it->first.index));
+        delta.push_back(Pair("index", (int)it->first.index));
         delta.push_back(Pair("height", it->first.blockHeight));
         delta.push_back(Pair("hash", it->first.hashBytes.GetHex()));
         delta.push_back(Pair("type", (int)it->first.type));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -424,9 +424,15 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
     if (!GetAddressIndex(hashBytes, type, addressIndex))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
 
+    std::set<std::string> txids;
+
     UniValue result(UniValue::VARR);
-    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++)
-        result.push_back(it->first.txhash.GetHex());
+    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++) {
+        std::string txid = it->first.txhash.GetHex();
+        if (txids.insert(txid).second) {
+            result.push_back(txid);
+        }
+    }
 
     return result;
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -396,3 +396,39 @@ UniValue setmocktime(const UniValue& params, bool fHelp)
 
     return NullUniValue;
 }
+
+UniValue getaddresstxids(const UniValue& params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error(
+            "getaddresstxids\n"
+            "\nReturns the txids for an address (requires addressindex to be enabled).\n"
+            "\nResult\n"
+            "[\n"
+            "  \"transactionid\"  (string) The transaction id\n"
+            "  ,...\n"
+            "]\n"
+        );
+
+    CBitcoinAddress address(params[0].get_str());
+    if (!address.IsValid())
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+
+    CKeyID keyID;
+    address.GetKeyID(keyID);
+
+    int type = 1; // TODO
+    std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
+
+    LOCK(cs_main);
+
+    if (!GetAddressIndex(keyID, type, addressIndex))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+
+    UniValue result(UniValue::VARR);
+    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++)
+        result.push_back(it->first.txhash.GetHex());
+
+    return result;
+
+}

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -410,20 +410,50 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
             "]\n"
         );
 
-    CBitcoinAddress address(params[0].get_str());
-    uint160 hashBytes;
-    int type = 0;
-    if (!address.GetIndexKey(hashBytes, type)) {
+    std::vector<std::pair<uint160, int> > addresses;
+
+    if (params[0].isStr()) {
+
+        CBitcoinAddress address(params[0].get_str());
+        uint160 hashBytes;
+        int type = 0;
+        if (!address.GetIndexKey(hashBytes, type)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+        }
+        addresses.push_back(std::make_pair(hashBytes, type));
+
+    } else if (params[0].isObject()) {
+
+        UniValue addressValues = find_value(params[0].get_obj(), "addresses");
+        if (!addressValues.isArray()) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Addresses is expected to be an array");
+        }
+
+        std::vector<UniValue> values = addressValues.getValues();
+
+        for (std::vector<UniValue>::iterator it = values.begin(); it != values.end(); ++it) {
+
+            CBitcoinAddress address(it->get_str());
+            uint160 hashBytes;
+            int type = 0;
+            if (!address.GetIndexKey(hashBytes, type)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+            }
+            addresses.push_back(std::make_pair(hashBytes, type));
+        }
+    } else {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
-    LOCK(cs_main);
+    for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); ++it) {
+        if (!GetAddressIndex((*it).first, (*it).second, addressIndex)) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+        }
+    }
 
-    if (!GetAddressIndex(hashBytes, type, addressIndex))
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
-
+    // TODO sort by height
     std::set<std::string> txids;
 
     UniValue result(UniValue::VARR);

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -463,13 +463,18 @@ UniValue getaddressbalance(const UniValue& params, bool fHelp)
     }
 
     CAmount balance = 0;
+    CAmount received = 0;
 
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++) {
+        if (it->second > 0) {
+            received += it->second;
+        }
         balance += it->second;
     }
 
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("balance", balance));
+    result.push_back(Pair("received", received));
 
     return result;
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -478,6 +478,10 @@ UniValue getaddressmempool(const UniValue& params, bool fHelp)
         delta.push_back(Pair("index", (int)it->first.index));
         delta.push_back(Pair("satoshis", it->second.amount));
         delta.push_back(Pair("timestamp", it->second.time));
+        if (it->second.amount < 0) {
+            delta.push_back(Pair("prevtxid", it->second.prevhash.GetHex()));
+            delta.push_back(Pair("prevout", (int)it->second.prevout));
+        }
         result.push_back(delta);
     }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -453,15 +453,22 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         }
     }
 
-    // TODO sort by height
     std::set<std::string> txids;
+    std::vector<std::pair<int, std::string> > vtxids;
 
-    UniValue result(UniValue::VARR);
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++) {
+        int height = it->first.blockHeight;
         std::string txid = it->first.txhash.GetHex();
         if (txids.insert(txid).second) {
-            result.push_back(txid);
+            vtxids.push_back(std::make_pair(height, txid));
         }
+    }
+
+    std::sort(vtxids.begin(), vtxids.end());
+
+    UniValue result(UniValue::VARR);
+    for (std::vector<std::pair<int, std::string> >::const_iterator it=vtxids.begin(); it!=vtxids.end(); it++) {
+        result.push_back(it->second);
     }
 
     return result;

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -411,18 +411,17 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         );
 
     CBitcoinAddress address(params[0].get_str());
-    if (!address.IsValid())
+    uint160 hashBytes;
+    int type = 0;
+    if (!address.GetIndexKey(hashBytes, type)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
+    }
 
-    CKeyID keyID;
-    address.GetKeyID(keyID);
-
-    int type = 1; // TODO
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
     LOCK(cs_main);
 
-    if (!GetAddressIndex(keyID, type, addressIndex))
+    if (!GetAddressIndex(hashBytes, type, addressIndex))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
 
     UniValue result(UniValue::VARR);

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -737,6 +737,7 @@ UniValue getspentinfo(const UniValue& params, bool fHelp)
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("txid", value.txid.GetHex()));
     obj.push_back(Pair("index", (int)value.inputIndex));
+    obj.push_back(Pair("height", value.blockHeight));
 
     return obj;
 }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -437,7 +437,7 @@ bool getAddressesFromParams(const UniValue& params, std::vector<std::pair<uint16
 
 UniValue getaddressutxos(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() != 1 || !params[0].isObject())
+    if (fHelp || params.size() != 1)
         throw runtime_error(
             "getaddressutxos\n"
             "\nReturns all unspent outputs for an address (requires addressindex to be enabled).\n"

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -431,8 +431,11 @@ bool getAddressesFromParams(const UniValue& params, std::vector<std::pair<uint16
     }
 
     return true;
+}
 
-
+bool heightSort(std::pair<CAddressUnspentKey, CAddressUnspentValue> a,
+                std::pair<CAddressUnspentKey, CAddressUnspentValue> b) {
+    return a.second.blockHeight < b.second.blockHeight;
 }
 
 UniValue getaddressutxos(const UniValue& params, bool fHelp)
@@ -468,6 +471,8 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
         }
     }
 
+    std::sort(unspentOutputs.begin(), unspentOutputs.end(), heightSort);
+
     UniValue result(UniValue::VARR);
 
     for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::const_iterator it=unspentOutputs.begin(); it!=unspentOutputs.end(); it++) {
@@ -478,6 +483,7 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
         output.push_back(Pair("outputIndex", it->first.index));
         output.push_back(Pair("script", HexStr(it->second.script.begin(), it->second.script.end())));
         output.push_back(Pair("satoshis", it->second.satoshis));
+        output.push_back(Pair("height", it->second.blockHeight));
         result.push_back(output);
     }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -567,24 +567,26 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         }
     }
 
-    std::set<std::string> txids;
-    std::vector<std::pair<int, std::string> > vtxids;
+    std::set<std::pair<int, std::string> > txids;
+    UniValue result(UniValue::VARR);
 
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=addressIndex.begin(); it!=addressIndex.end(); it++) {
         int height = it->first.blockHeight;
         std::string txid = it->first.txhash.GetHex();
-        if (txids.insert(txid).second) {
-            vtxids.push_back(std::make_pair(height, txid));
+
+        if (addresses.size() > 1) {
+            txids.insert(std::make_pair(height, txid));
+        } else {
+            if (txids.insert(std::make_pair(height, txid)).second) {
+                result.push_back(txid);
+            }
         }
     }
 
     if (addresses.size() > 1) {
-        std::sort(vtxids.begin(), vtxids.end());
-    }
-
-    UniValue result(UniValue::VARR);
-    for (std::vector<std::pair<int, std::string> >::const_iterator it=vtxids.begin(); it!=vtxids.end(); it++) {
-        result.push_back(it->second);
+        for (std::set<std::pair<int, std::string> >::const_iterator it=txids.begin(); it!=txids.end(); it++) {
+            result.push_back(it->second);
+        }
     }
 
     return result;

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -668,11 +668,28 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid address");
     }
 
+    int start = 0;
+    int end = 0;
+    if (params[0].isObject()) {
+        UniValue startValue = find_value(params[0].get_obj(), "start");
+        UniValue endValue = find_value(params[0].get_obj(), "end");
+        if (startValue.isNum() && endValue.isNum()) {
+            start = startValue.get_int();
+            end = startValue.get_int();
+        }
+    }
+
     std::vector<std::pair<CAddressIndexKey, CAmount> > addressIndex;
 
     for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
-        if (!GetAddressIndex((*it).first, (*it).second, addressIndex)) {
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+        if (start > 0 && end > 0) {
+            if (!GetAddressIndex((*it).first, (*it).second, addressIndex, start, end)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+            }
+        } else {
+            if (!GetAddressIndex((*it).first, (*it).second, addressIndex)) {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No information available for address");
+            }
         }
     }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -464,7 +464,9 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         }
     }
 
-    std::sort(vtxids.begin(), vtxids.end());
+    if (addresses.size() > 1) {
+        std::sort(vtxids.begin(), vtxids.end());
+    }
 
     UniValue result(UniValue::VARR);
     for (std::vector<std::pair<int, std::string> >::const_iterator it=vtxids.begin(); it!=vtxids.end(); it++) {

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -475,7 +475,6 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
         output.push_back(Pair("addressType", (int)it->first.type));
         output.push_back(Pair("addressHash", it->first.hashBytes.GetHex()));
         output.push_back(Pair("txid", it->first.txhash.GetHex()));
-        output.push_back(Pair("height", it->first.blockHeight));
         output.push_back(Pair("outputIndex", it->first.index));
         output.push_back(Pair("script", HexStr(it->second.script.begin(), it->second.script.end())));
         output.push_back(Pair("satoshis", it->second.satoshis));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -675,7 +675,7 @@ UniValue getaddresstxids(const UniValue& params, bool fHelp)
         UniValue endValue = find_value(params[0].get_obj(), "end");
         if (startValue.isNum() && endValue.isNum()) {
             start = startValue.get_int();
-            end = startValue.get_int();
+            end = endValue.get_int();
         }
     }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -523,8 +523,16 @@ UniValue getaddressutxos(const UniValue& params, bool fHelp)
 
     for (std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> >::const_iterator it=unspentOutputs.begin(); it!=unspentOutputs.end(); it++) {
         UniValue output(UniValue::VOBJ);
-        output.push_back(Pair("addressType", (int)it->first.type));
-        output.push_back(Pair("addressHash", it->first.hashBytes.GetHex()));
+        std::string address;
+        if (it->first.type == 2) {
+            address = CBitcoinAddress(CScriptID(it->first.hashBytes)).ToString();
+        } else if (it->first.type == 1) {
+            address = CBitcoinAddress(CKeyID(it->first.hashBytes)).ToString();
+        } else {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unknown address type");
+        }
+
+        output.push_back(Pair("address", address));
         output.push_back(Pair("txid", it->first.txhash.GetHex()));
         output.push_back(Pair("outputIndex", it->first.index));
         output.push_back(Pair("script", HexStr(it->second.script.begin(), it->second.script.end())));

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -99,6 +99,7 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         if (GetSpentIndex(spentKey, spentInfo)) {
             out.push_back(Pair("spentTxId", spentInfo.txid.GetHex()));
             out.push_back(Pair("spentIndex", (int)spentInfo.inputIndex));
+            out.push_back(Pair("spentHeight", spentInfo.blockHeight));
         }
 
         vout.push_back(out);

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -101,12 +101,14 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         if (mi != mapBlockIndex.end() && (*mi).second) {
             CBlockIndex* pindex = (*mi).second;
             if (chainActive.Contains(pindex)) {
+                entry.push_back(Pair("height", pindex->nHeight));
                 entry.push_back(Pair("confirmations", 1 + chainActive.Height() - pindex->nHeight));
                 entry.push_back(Pair("time", pindex->GetBlockTime()));
                 entry.push_back(Pair("blocktime", pindex->GetBlockTime()));
-            }
-            else
+            } else {
+                entry.push_back(Pair("height", -1));
                 entry.push_back(Pair("confirmations", 0));
+            }
         }
     }
 }

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -61,7 +61,8 @@ void ScriptPubKeyToJSON(const CScript& scriptPubKey, UniValue& out, bool fInclud
 
 void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 {
-    entry.push_back(Pair("txid", tx.GetHash().GetHex()));
+    uint256 txid = tx.GetHash();
+    entry.push_back(Pair("txid", txid.GetHex()));
     entry.push_back(Pair("size", (int)::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION)));
     entry.push_back(Pair("version", tx.nVersion));
     entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
@@ -91,6 +92,15 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
         UniValue o(UniValue::VOBJ);
         ScriptPubKeyToJSON(txout.scriptPubKey, o, true);
         out.push_back(Pair("scriptPubKey", o));
+
+        // Add spent information if spentindex is enabled
+        CSpentIndexValue spentInfo;
+        CSpentIndexKey spentKey(txid, i);
+        if (GetSpentIndex(spentKey, spentInfo)) {
+            out.push_back(Pair("spentTxId", spentInfo.txid.GetHex()));
+            out.push_back(Pair("spentIndex", (int)spentInfo.inputIndex));
+        }
+
         vout.push_back(out);
     }
     entry.push_back(Pair("vout", vout));

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -290,6 +290,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "verifytxoutproof",       &verifytxoutproof,       true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
+    { "blockchain",         "getspentinfo",           &getspentinfo,           true  },
 
     /* Mining */
     { "mining",             "getblocktemplate",       &getblocktemplate,       true  },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -290,7 +290,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "verifytxoutproof",       &verifytxoutproof,       true  },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        true  },
     { "blockchain",         "verifychain",            &verifychain,            true  },
-    { "blockchain",         "getspentinfo",           &getspentinfo,           true  },
+    { "blockchain",         "getspentinfo",           &getspentinfo,           false },
 
     /* Mining */
     { "mining",             "getblocktemplate",       &getblocktemplate,       true  },
@@ -316,7 +316,7 @@ static const CRPCCommand vRPCCommands[] =
 #endif
 
     /* Address index */
-    { "addressindex",       "getaddressmempool",      &getaddressmempool,      false },
+    { "addressindex",       "getaddressmempool",      &getaddressmempool,      true  },
     { "addressindex",       "getaddressutxos",        &getaddressutxos,        false },
     { "addressindex",       "getaddressdeltas",       &getaddressdeltas,       false },
     { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -313,6 +313,9 @@ static const CRPCCommand vRPCCommands[] =
     { "rawtransactions",    "fundrawtransaction",     &fundrawtransaction,     false },
 #endif
 
+    /* Address index */
+    { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },
+
     /* Utility functions */
     { "util",               "createmultisig",         &createmultisig,         true  },
     { "util",               "validateaddress",        &validateaddress,        true  }, /* uses wallet if enabled */

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -315,6 +315,7 @@ static const CRPCCommand vRPCCommands[] =
 #endif
 
     /* Address index */
+    { "addressindex",       "getaddressmempool",      &getaddressmempool,      false },
     { "addressindex",       "getaddressutxos",        &getaddressutxos,        false },
     { "addressindex",       "getaddressdeltas",       &getaddressdeltas,       false },
     { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -278,6 +278,7 @@ static const CRPCCommand vRPCCommands[] =
     { "blockchain",         "getbestblockhash",       &getbestblockhash,       true  },
     { "blockchain",         "getblockcount",          &getblockcount,          true  },
     { "blockchain",         "getblock",               &getblock,               true  },
+    { "blockchain",         "getblockhashes",         &getblockhashes,         true  },
     { "blockchain",         "getblockhash",           &getblockhash,           true  },
     { "blockchain",         "getblockheader",         &getblockheader,         true  },
     { "blockchain",         "getchaintips",           &getchaintips,           true  },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -315,6 +315,7 @@ static const CRPCCommand vRPCCommands[] =
 #endif
 
     /* Address index */
+    { "addressindex",       "getaddressutxos",        &getaddressutxos,        false },
     { "addressindex",       "getaddressdeltas",       &getaddressdeltas,       false },
     { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },
     { "addressindex",       "getaddressbalance",      &getaddressbalance,      false },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -315,6 +315,7 @@ static const CRPCCommand vRPCCommands[] =
 
     /* Address index */
     { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },
+    { "addressindex",       "getaddressbalance",      &getaddressbalance,      false },
 
     /* Utility functions */
     { "util",               "createmultisig",         &createmultisig,         true  },

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -315,6 +315,7 @@ static const CRPCCommand vRPCCommands[] =
 #endif
 
     /* Address index */
+    { "addressindex",       "getaddressdeltas",       &getaddressdeltas,       false },
     { "addressindex",       "getaddresstxids",        &getaddresstxids,        false },
     { "addressindex",       "getaddressbalance",      &getaddressbalance,      false },
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -167,6 +167,7 @@ extern void EnsureWalletIsUnlocked();
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpcnet.cpp
 extern UniValue getaddresstxids(const UniValue& params, bool fHelp);
+extern UniValue getaddressbalance(const UniValue& params, bool fHelp);
 
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
 extern UniValue ping(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -166,6 +166,7 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 extern void EnsureWalletIsUnlocked();
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpcnet.cpp
+extern UniValue getaddressmempool(const UniValue& params, bool fHelp);
 extern UniValue getaddressutxos(const UniValue& params, bool fHelp);
 extern UniValue getaddressdeltas(const UniValue& params, bool fHelp);
 extern UniValue getaddresstxids(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -271,6 +271,7 @@ extern UniValue verifychain(const UniValue& params, bool fHelp);
 extern UniValue getchaintips(const UniValue& params, bool fHelp);
 extern UniValue invalidateblock(const UniValue& params, bool fHelp);
 extern UniValue reconsiderblock(const UniValue& params, bool fHelp);
+extern UniValue getspentinfo(const UniValue& params, bool fHelp);
 
 bool StartRPC();
 void InterruptRPC();

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -166,6 +166,7 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 extern void EnsureWalletIsUnlocked();
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpcnet.cpp
+extern UniValue getaddressdeltas(const UniValue& params, bool fHelp);
 extern UniValue getaddresstxids(const UniValue& params, bool fHelp);
 extern UniValue getaddressbalance(const UniValue& params, bool fHelp);
 

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -258,6 +258,7 @@ extern UniValue getdifficulty(const UniValue& params, bool fHelp);
 extern UniValue settxfee(const UniValue& params, bool fHelp);
 extern UniValue getmempoolinfo(const UniValue& params, bool fHelp);
 extern UniValue getrawmempool(const UniValue& params, bool fHelp);
+extern UniValue getblockhashes(const UniValue& params, bool fHelp);
 extern UniValue getblockhash(const UniValue& params, bool fHelp);
 extern UniValue getblockheader(const UniValue& params, bool fHelp);
 extern UniValue getblock(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -166,6 +166,7 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 extern void EnsureWalletIsUnlocked();
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpcnet.cpp
+extern UniValue getaddressutxos(const UniValue& params, bool fHelp);
 extern UniValue getaddressdeltas(const UniValue& params, bool fHelp);
 extern UniValue getaddresstxids(const UniValue& params, bool fHelp);
 extern UniValue getaddressbalance(const UniValue& params, bool fHelp);

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -166,6 +166,8 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 extern void EnsureWalletIsUnlocked();
 
 extern UniValue getconnectioncount(const UniValue& params, bool fHelp); // in rpcnet.cpp
+extern UniValue getaddresstxids(const UniValue& params, bool fHelp);
+
 extern UniValue getpeerinfo(const UniValue& params, bool fHelp);
 extern UniValue ping(const UniValue& params, bool fHelp);
 extern UniValue addnode(const UniValue& params, bool fHelp);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -201,6 +201,17 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     return subscript.GetSigOpCount(true);
 }
 
+bool CScript::IsPayToPublicKeyHash() const
+{
+    // Extra-fast test for pay-to-pubkey-hash CScripts:
+    return (this->size() == 25 &&
+	    (*this)[0] == OP_DUP &&
+	    (*this)[1] == OP_HASH160 &&
+	    (*this)[2] == 0x14 &&
+	    (*this)[23] == OP_EQUALVERIFY &&
+	    (*this)[24] == OP_CHECKSIG);
+}
+
 bool CScript::IsPayToScriptHash() const
 {
     // Extra-fast test for pay-to-script-hash CScripts:

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -596,6 +596,8 @@ public:
      */
     unsigned int GetSigOpCount(const CScript& scriptSig) const;
 
+    bool IsPayToPublicKeyHash() const;
+
     bool IsPayToScriptHash() const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -91,6 +91,11 @@ template<typename Stream> inline void ser_writedata32(Stream &s, uint32_t obj)
     obj = htole32(obj);
     s.write((char*)&obj, 4);
 }
+template<typename Stream> inline void ser_writedata32be(Stream &s, uint32_t obj)
+{
+    obj = htobe32(obj);
+    s.write((char*)&obj, 4);
+}
 template<typename Stream> inline void ser_writedata64(Stream &s, uint64_t obj)
 {
     obj = htole64(obj);
@@ -113,6 +118,12 @@ template<typename Stream> inline uint32_t ser_readdata32(Stream &s)
     uint32_t obj;
     s.read((char*)&obj, 4);
     return le32toh(obj);
+}
+template<typename Stream> inline uint32_t ser_readdata32be(Stream &s)
+{
+    uint32_t obj;
+    s.read((char*)&obj, 4);
+    return be32toh(obj);
 }
 template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 {

--- a/src/test/script_P2PKH_tests.cpp
+++ b/src/test/script_P2PKH_tests.cpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "script/script.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+
+BOOST_FIXTURE_TEST_SUITE(script_P2PKH_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(IsPayToPublicKeyHash)
+{
+    // Test CScript::IsPayToPublicKeyHash()
+    uint160 dummy;
+    CScript p2pkh;
+    p2pkh << OP_DUP << OP_HASH160 << ToByteVector(dummy) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK(p2pkh.IsPayToPublicKeyHash());
+
+    static const unsigned char direct[] = {
+        OP_DUP, OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUALVERIFY, OP_CHECKSIG
+    };
+    BOOST_CHECK(CScript(direct, direct+sizeof(direct)).IsPayToPublicKeyHash());
+
+    static const unsigned char notp2pkh1[] = {
+        OP_DUP, OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUALVERIFY, OP_CHECKSIG, OP_CHECKSIG
+    };
+    BOOST_CHECK(!CScript(notp2pkh1, notp2pkh1+sizeof(notp2pkh1)).IsPayToPublicKeyHash());
+
+    static const unsigned char p2sh[] = {
+        OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL
+    };
+    BOOST_CHECK(!CScript(p2sh, p2sh+sizeof(p2sh)).IsPayToPublicKeyHash());
+
+    static const unsigned char extra[] = {
+        OP_DUP, OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUALVERIFY, OP_CHECKSIG, OP_CHECKSIG
+    };
+    BOOST_CHECK(!CScript(extra, extra+sizeof(extra)).IsPayToPublicKeyHash());
+
+    static const unsigned char missing[] = {
+        OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUALVERIFY, OP_CHECKSIG, OP_RETURN
+    };
+    BOOST_CHECK(!CScript(missing, missing+sizeof(missing)).IsPayToPublicKeyHash());
+
+    static const unsigned char missing2[] = {
+        OP_DUP, OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    };
+    BOOST_CHECK(!CScript(missing2, missing2+sizeof(missing)).IsPayToPublicKeyHash());
+
+    static const unsigned char tooshort[] = {
+        OP_DUP, OP_HASH160, 2, 0,0, OP_EQUALVERIFY, OP_CHECKSIG
+    };
+    BOOST_CHECK(!CScript(tooshort, tooshort+sizeof(direct)).IsPayToPublicKeyHash());
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -172,6 +172,13 @@ bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKe
     return WriteBatch(batch);
 }
 
+bool CBlockTreeDB::EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
+    CDBBatch batch(&GetObfuscateKey());
+    for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+        batch.Erase(make_pair(DB_ADDRESSINDEX, it->first));
+    return WriteBatch(batch);
+}
+
 bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, int type,
                                     std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
                                     int start, int end) {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -167,7 +167,7 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
 bool CBlockTreeDB::WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount > >&vect) {
     CDBBatch batch(&GetObfuscateKey());
     for (std::vector<std::pair<CAddressIndexKey, CAmount> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
-	batch.Write(make_pair(DB_ADDRESSINDEX, it->first), it->second);
+        batch.Write(make_pair(DB_ADDRESSINDEX, it->first), it->second);
     return WriteBatch(batch);
 }
 
@@ -175,7 +175,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, int type, std::vector<s
 
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
-    pcursor->Seek(make_pair(DB_ADDRESSINDEX, addressHash)); //TODO include type
+    pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, addressHash)));
 
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -24,6 +24,7 @@ static const char DB_TXINDEX = 't';
 static const char DB_ADDRESSINDEX = 'a';
 static const char DB_ADDRESSUNSPENTINDEX = 'u';
 static const char DB_TIMESTAMPINDEX = 's';
+static const char DB_SPENTINDEX = 'p';
 static const char DB_BLOCK_INDEX = 'b';
 
 static const char DB_BEST_BLOCK = 'B';
@@ -163,6 +164,22 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
     CDBBatch batch(&GetObfuscateKey());
     for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
         batch.Write(make_pair(DB_TXINDEX, it->first), it->second);
+    return WriteBatch(batch);
+}
+
+bool CBlockTreeDB::ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value) {
+    return Read(make_pair(DB_SPENTINDEX, key), value);
+}
+
+bool CBlockTreeDB::UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect) {
+    CDBBatch batch(&GetObfuscateKey());
+    for (std::vector<std::pair<CSpentIndexKey,CSpentIndexValue> >::const_iterator it=vect.begin(); it!=vect.end(); it++) {
+        if (it->second.IsNull()) {
+            batch.Erase(make_pair(DB_SPENTINDEX, it->first));
+        } else {
+            batch.Write(make_pair(DB_SPENTINDEX, it->first), it->second);
+        }
+    }
     return WriteBatch(batch);
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -242,7 +242,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, int type,
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
     if (start > 0 && end > 0) {
-        pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, addressHash, start)));
+        pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorHeightKey(type, addressHash, start)));
     } else {
         pcursor->Seek(make_pair(DB_ADDRESSINDEX, CAddressIndexIteratorKey(type, addressHash)));
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -271,7 +271,7 @@ bool CBlockTreeDB::ReadAddressIndex(uint160 addressHash, int type,
 
 bool CBlockTreeDB::WriteTimestampIndex(const CTimestampIndexKey &timestampIndex) {
     CDBBatch batch(&GetObfuscateKey());
-    batch.Write(make_pair(DB_TIMESTAMPINDEX, timestampIndex), NULL);
+    batch.Write(make_pair(DB_TIMESTAMPINDEX, timestampIndex), 0);
     return WriteBatch(batch);
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -21,6 +21,7 @@ struct CAddressUnspentKey;
 struct CAddressUnspentValue;
 struct CAddressIndexKey;
 struct CAddressIndexIteratorKey;
+struct CAddressIndexIteratorHeightKey;
 struct CTimestampIndexKey;
 struct CTimestampIndexIteratorKey;
 struct CSpentIndexKey;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -18,6 +18,7 @@ class CBlockFileInfo;
 class CBlockIndex;
 struct CDiskTxPos;
 struct CAddressIndexKey;
+struct CAddressIndexIteratorKey;
 class uint256;
 
 //! -dbcache default (MiB)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -17,6 +17,8 @@
 class CBlockFileInfo;
 class CBlockIndex;
 struct CDiskTxPos;
+struct CAddressUnspentKey;
+struct CAddressUnspentValue;
 struct CAddressIndexKey;
 struct CAddressIndexIteratorKey;
 struct CTimestampIndexKey;
@@ -61,6 +63,9 @@ public:
     bool ReadReindexing(bool &fReindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
+    bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue > >&vect);
+    bool ReadAddressUnspentIndex(uint160 addressHash, int type,
+                                 std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &vect);
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool ReadAddressIndex(uint160 addressHash, int type,

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -17,6 +17,7 @@
 class CBlockFileInfo;
 class CBlockIndex;
 struct CDiskTxPos;
+struct CAddressIndexKey;
 class uint256;
 
 //! -dbcache default (MiB)
@@ -57,6 +58,8 @@ public:
     bool ReadReindexing(bool &fReindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
+    bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
+    bool ReadAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts();

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -23,6 +23,8 @@ struct CAddressIndexKey;
 struct CAddressIndexIteratorKey;
 struct CTimestampIndexKey;
 struct CTimestampIndexIteratorKey;
+struct CSpentIndexKey;
+struct CSpentIndexValue;
 class uint256;
 
 //! -dbcache default (MiB)
@@ -63,6 +65,8 @@ public:
     bool ReadReindexing(bool &fReindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
+    bool ReadSpentIndex(CSpentIndexKey &key, CSpentIndexValue &value);
+    bool UpdateSpentIndex(const std::vector<std::pair<CSpentIndexKey, CSpentIndexValue> >&vect);
     bool UpdateAddressUnspentIndex(const std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue > >&vect);
     bool ReadAddressUnspentIndex(uint160 addressHash, int type,
                                  std::vector<std::pair<CAddressUnspentKey, CAddressUnspentValue> > &vect);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -62,7 +62,9 @@ public:
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
-    bool ReadAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
+    bool ReadAddressIndex(uint160 addressHash, int type,
+                          std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
+                          int start = 0, int end = 0);
     bool WriteTimestampIndex(const CTimestampIndexKey &timestampIndex);
     bool ReadTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &vect);
     bool WriteFlag(const std::string &name, bool fValue);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -62,6 +62,7 @@ public:
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
+    bool EraseAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool ReadAddressIndex(uint160 addressHash, int type,
                           std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex,
                           int start = 0, int end = 0);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -19,6 +19,8 @@ class CBlockIndex;
 struct CDiskTxPos;
 struct CAddressIndexKey;
 struct CAddressIndexIteratorKey;
+struct CTimestampIndexKey;
+struct CTimestampIndexIteratorKey;
 class uint256;
 
 //! -dbcache default (MiB)
@@ -61,6 +63,8 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteAddressIndex(const std::vector<std::pair<CAddressIndexKey, CAmount> > &vect);
     bool ReadAddressIndex(uint160 addressHash, int type, std::vector<std::pair<CAddressIndexKey, CAmount> > &addressIndex);
+    bool WriteTimestampIndex(const CTimestampIndexKey &timestampIndex);
+    bool ReadTimestampIndex(const unsigned int &high, const unsigned int &low, std::vector<uint256> &vect);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool LoadBlockIndexGuts();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -417,6 +417,80 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     return true;
 }
 
+void CTxMemPool::addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view)
+{
+    LOCK(cs);
+    const CTransaction& tx = entry.GetTx();
+    std::vector<CMempoolAddressDeltaKey> inserted;
+
+    uint256 txhash = tx.GetHash();
+    for (unsigned int j = 0; j < tx.vin.size(); j++) {
+        const CTxIn input = tx.vin[j];
+        const CTxOut &prevout = view.GetOutputFor(input);
+        if (prevout.scriptPubKey.IsPayToScriptHash()) {
+            vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+2, prevout.scriptPubKey.begin()+22);
+            CMempoolAddressDeltaKey key(2, uint160(hashBytes), txhash, j, true);
+            CMempoolAddressDelta delta(entry.GetTime(), prevout.nValue * -1, input.prevout.hash, input.prevout.n);
+            mapAddress.insert(make_pair(key, delta));
+            inserted.push_back(key);
+        } else if (prevout.scriptPubKey.IsPayToPublicKeyHash()) {
+            vector<unsigned char> hashBytes(prevout.scriptPubKey.begin()+3, prevout.scriptPubKey.begin()+23);
+            CMempoolAddressDeltaKey key(1, uint160(hashBytes), txhash, j, true);
+            CMempoolAddressDelta delta(entry.GetTime(), prevout.nValue * -1, input.prevout.hash, input.prevout.n);
+            mapAddress.insert(make_pair(key, delta));
+            inserted.push_back(key);
+        }
+    }
+
+    for (unsigned int k = 0; k < tx.vout.size(); k++) {
+        const CTxOut &out = tx.vout[k];
+        if (out.scriptPubKey.IsPayToScriptHash()) {
+            vector<unsigned char> hashBytes(out.scriptPubKey.begin()+2, out.scriptPubKey.begin()+22);
+            CMempoolAddressDeltaKey key(2, uint160(hashBytes), txhash, k, false);
+            mapAddress.insert(make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
+            inserted.push_back(key);
+        } else if (out.scriptPubKey.IsPayToPublicKeyHash()) {
+            vector<unsigned char> hashBytes(out.scriptPubKey.begin()+3, out.scriptPubKey.begin()+23);
+            std::pair<addressDeltaMap::iterator,bool> ret;
+            CMempoolAddressDeltaKey key(1, uint160(hashBytes), txhash, k, false);
+            mapAddress.insert(make_pair(key, CMempoolAddressDelta(entry.GetTime(), out.nValue)));
+            inserted.push_back(key);
+        }
+    }
+
+    mapAddressInserted.insert(make_pair(txhash, inserted));
+}
+
+bool CTxMemPool::getAddressIndex(std::vector<std::pair<uint160, int> > &addresses,
+                                 std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results)
+{
+    LOCK(cs);
+    for (std::vector<std::pair<uint160, int> >::iterator it = addresses.begin(); it != addresses.end(); it++) {
+        addressDeltaMap::iterator ait = mapAddress.lower_bound(CMempoolAddressDeltaKey((*it).second, (*it).first));
+        while (ait != mapAddress.end() && (*ait).first.addressBytes == (*it).first) {
+            results.push_back(*ait);
+            ait++;
+        }
+    }
+    return true;
+}
+
+bool CTxMemPool::removeAddressIndex(const uint256 txhash)
+{
+    LOCK(cs);
+    addressDeltaMapInserted::iterator it = mapAddressInserted.find(txhash);
+
+    if (it != mapAddressInserted.end()) {
+        std::vector<CMempoolAddressDeltaKey> keys = (*it).second;
+        for (std::vector<CMempoolAddressDeltaKey>::iterator mit = keys.begin(); mit != keys.end(); mit++) {
+            mapAddress.erase(*mit);
+        }
+        mapAddressInserted.erase(it);
+    }
+
+    return true;
+}
+
 void CTxMemPool::removeUnchecked(txiter it)
 {
     const uint256 hash = it->GetTx().GetHash();
@@ -430,6 +504,7 @@ void CTxMemPool::removeUnchecked(txiter it)
     mapTx.erase(it);
     nTransactionsUpdated++;
     minerPolicyEstimator->removeTx(hash);
+    removeAddressIndex(hash);
 }
 
 // Calculates descendants of entry that are not already in setDescendants, and adds to

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -9,6 +9,7 @@
 #include <list>
 #include <set>
 
+#include "addressindex.h"
 #include "amount.h"
 #include "coins.h"
 #include "primitives/transaction.h"
@@ -389,6 +390,12 @@ private:
     typedef std::map<txiter, TxLinks, CompareIteratorByHash> txlinksMap;
     txlinksMap mapLinks;
 
+    typedef std::map<CMempoolAddressDeltaKey, CMempoolAddressDelta, CMempoolAddressDeltaKeyCompare> addressDeltaMap;
+    addressDeltaMap mapAddress;
+
+    typedef std::map<uint256, std::vector<CMempoolAddressDeltaKey> > addressDeltaMapInserted;
+    addressDeltaMapInserted mapAddressInserted;
+
     void UpdateParent(txiter entry, txiter parent, bool add);
     void UpdateChild(txiter entry, txiter child, bool add);
 
@@ -419,6 +426,11 @@ public:
     // then invoke the second version.
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool fCurrentEstimate = true);
+
+    void addAddressIndex(const CTxMemPoolEntry &entry, const CCoinsViewCache &view);
+    bool getAddressIndex(std::vector<std::pair<uint160, int> > &addresses,
+                         std::vector<std::pair<CMempoolAddressDeltaKey, CMempoolAddressDelta> > &results);
+    bool removeAddressIndex(const uint256 txhash);
 
     void remove(const CTransaction &tx, std::list<CTransaction>& removed, bool fRecursive = false);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);


### PR DESCRIPTION
Adds configuration options `-addressindex`. `-timestampindex` and `-spentindex` with associated RPC methods for retrieving txids, balances, and unspent outputs by address:
- `getaddresstxids` - Returns transaction txid history for any address or addresses
- `getaddressbalance` - Returns balance for any address or addresses
- `getaddressutxos` - Returns unspent outputs for any address or addresses
- `getaddressmempool` - Returns mempool transaction deltas for any address or addresses
- `getblockhashes` - Returns an array of block hashes within a range of timestamps
- `getspentinfo` - Returns txid and input index that spent an output

Latest build release: https://github.com/braydonf/bitcoin/releases/tag/v0.12.0-bitcore-beta6
