### PR TITLE
Revert "rpc: add input confirmations to getrawtransaction"

### DIFF
--- a/qa/rpc-tests/spentindex.py
+++ b/qa/rpc-tests/spentindex.py
@@ -103,10 +103,6 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(txVerbose3["vin"][0]["value"], Decimal(unspent[0]["amount"]))
         assert_equal(txVerbose3["vin"][0]["valueSat"], amount)
 
-        # Check that the input confirmations work for mempool unconfirmed transactions
-        assert_equal(txVerbose3["vin"][0].has_key("height"), False)
-        assert_equal(txVerbose3["vin"][0]["confirmations"], 0)
-
         # Check the database index
         self.nodes[0].generate(1)
         self.sync_all()
@@ -115,10 +111,6 @@ class SpentIndexTest(BitcoinTestFramework):
         assert_equal(txVerbose4["vin"][0]["address"], address2)
         assert_equal(txVerbose4["vin"][0]["value"], Decimal(unspent[0]["amount"]))
         assert_equal(txVerbose4["vin"][0]["valueSat"], amount)
-
-        # Check that the input confirmations work
-        assert_equal(txVerbose4["vin"][0]["height"], 107)
-        assert_equal(txVerbose4["vin"][0]["confirmations"], 1)
 
         print "Passed\n"
 

--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -83,13 +83,6 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
             CSpentIndexValue spentInfo;
             CSpentIndexKey spentKey(txin.prevout.hash, txin.prevout.n);
             if (GetSpentIndex(spentKey, spentInfo)) {
-                // Unconfirmed spentInfo have a height of -1, block 0 is unspendable
-                if (spentInfo.blockHeight > 0) {
-                    in.push_back(Pair("height", spentInfo.blockHeight));
-                    in.push_back(Pair("confirmations", 1 + chainActive.Height() - spentInfo.blockHeight));
-                } else {
-                    in.push_back(Pair("confirmations", 0));
-                }
                 in.push_back(Pair("value", ValueFromAmount(spentInfo.satoshis)));
                 in.push_back(Pair("valueSat", spentInfo.satoshis));
                 if (spentInfo.addressType == 1) {


### PR DESCRIPTION
After reviewing the changes again and running the bitcoin-cli utility on transactions. I looks like the input height and confirmations it's not giving the value as expected. It's relative to the spending transaction vs. being relative to the transaction output that is being spent. And hence will always be the same as the transaction and not useful.

Example:

```
{
  [snip]
  "txid": "c609d2521c952d8505502e5c292d85e4a15a80030d8d5358dbcbceaacb4184de",
  "size": 519,
  "version": 1,
  "locktime": 0,
  "vin": [
    {
      "txid": "c2a9517a13c91c4fcfc87c48acb18d2d787f2b39c60b9e33cd0eb1b66529e787",
      "vout": 1,
      [snip]
      "height": 870947,
      "confirmations": 10,
      [snip]
    }, 
    {
      "txid": "db1fabc16762c5f8915b344612923caf9151939ee5b1d89cf52a7cb0fabca221",
      "vout": 1,
      [snip]
      "height": 870947,
      "confirmations": 10,
      [snip]
    }, 
    {
      "txid": "48f1a7797def7d9d5e96e6ec11d0c6de312d03c9bc6e1047e71fe2c8ed51f766",
      "vout": 0,
      [snip]
      "height": 870947,
      "confirmations": 10,
      [snip]
    }
  ],
  "vout": [
    [snip]
  ],
  "blockhash": "00000000000000fb235df898d6e43683a111a734b78c67fe09d0dcad042031c8",
  "height": 870947,
  "confirmations": 10,
  "time": 1466038057,
  "blocktime": 1466038057
}
```
