### PR TITLE
DisconnectBlock(): write spentindex to disk

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2360,6 +2360,12 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
         }
     }
 
+    if (fSpentIndex) {
+        if (!pblocktree->UpdateSpentIndex(spentIndex)) {
+            return AbortNode(state, "Failed to write transaction index");
+        }
+    }
+
     return fClean;
 }
 


### PR DESCRIPTION
Resolves #56. Adding the same code to `DisconnectBlock()` as already exists in `ConnectBlock()`, very simple and safe change.